### PR TITLE
fix: panic when running go-appimagetool in a git repo without a single commit

### DIFF
--- a/src/appimagetool/appimagetool.go
+++ b/src/appimagetool/appimagetool.go
@@ -260,11 +260,11 @@ func GenerateAppImage(appdir string) {
 			log.Println("git root:", gitRoot)
 			if version == "" {
 				gitHead, err := gitRepo.Head()
-				version = gitHead.Hash().String()[:7] // This equals 'git rev-parse --short HEAD'
 				if err != nil {
 					os.Stderr.WriteString("Could not determine version automatically, please supply the application version as $VERSION " + filepath.Base(os.Args[0]) + " ... \n")
 					os.Exit(1)
 				} else {
+					version = gitHead.Hash().String()[:7] // This equals 'git rev-parse --short HEAD'
 					log.Println("NOTE: Using", version, "from 'git rev-parse --short HEAD' as the version")
 					log.Println("      Please set the $VERSION environment variable if this is not intended")
 				}


### PR DESCRIPTION

Fixes #62

Check the error associated with retrieving the commit hash before slicing the gitHead.Hash()