### PR TITLE
fix: non-travis builds contain illegal character ':'

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,8 +28,8 @@ if [ ! -z "$TRAVIS_BUILD_NUMBER" ] ; then
   export COMMIT="${TRAVIS_BUILD_NUMBER}" # "${TRAVIS_JOB_WEB_URL} on $(date +'%Y-%m-%d_%T')"
   export VERSION=$TRAVIS_BUILD_NUMBER
 else
-  export COMMIT=$(date '+%Y-%m-%d_%T')
-  export VERSION=$(date '+%Y-%m-%d_%T')
+  export COMMIT=$(date '+%Y-%m-%d_%H%M%S')
+  export VERSION=$(date '+%Y-%m-%d_%H%M%S')
 fi
 
 # Get pinned version of Go directly from upstream


### PR DESCRIPTION
The %T expanded to 00:00:00 which is contains the character `:`. Many systems including shells, CIs do not like to keep this character and causes errors, or sometimes we need to escape these characters. It would be nice if the character is removed

