### PR TITLE
Fix arch detection

### DIFF
--- a/src/appimagetool/appimagetool.go
+++ b/src/appimagetool/appimagetool.go
@@ -6,8 +6,11 @@ package main
 import (
 	// "crypto/md5"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"github.com/probonopd/go-zsyncmake/zsync"
+	"gopkg.in/ini.v1"
 	"io/ioutil"
 	"log"
 	"os"
@@ -16,9 +19,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/probonopd/go-zsyncmake/zsync"
-	"gopkg.in/ini.v1"
 
 	"github.com/probonopd/go-appimage/internal/helpers"
 )


### PR DESCRIPTION
Previously, go-appimagetool did not stop if a proper architecture was
not detected from the .so. files or the binary. As it did not halt,
the arch variable was set to empty string (''). This led to a
filenotfound panic, because the tool was looking for
`release-` instead of `release-x86_64` as the arch variable was
empty. go-appimagetoold should properly halt if the detection of
ARCH variable did not complete successfully, so that they
can provide the ARCH environment variable instead.