### PR TITLE
fix: AppImageUpdate failing on appimages generated using go-appimage

### DIFF
--- a/src/appimagetool/appimagetool.go
+++ b/src/appimagetool/appimagetool.go
@@ -578,17 +578,19 @@ func GenerateAppImage(appdir string) {
 			helpers.PrintError("EmbedStringInSegment", err)
 			os.Exit(1)
 		}
-	}
-
-	// Embed SHA256 digest into '.sha256_sig' section if it exists
-	// This is not part of the AppImageSpec yet, but in the future we will want to put this into the AppImageSpec:
-	// If an AppImage is not signed, it should have the SHA256 digest in the '.sha256_sig' section; this might
-	// eventually remove the need for an extra '.digest_md5' section and hence simplify the format
-	digest := helpers.CalculateSHA256Digest(target)
-	err = helpers.EmbedStringInSegment(target, ".sha256_sig", digest)
-	if err != nil {
-		helpers.PrintError("EmbedStringInSegment", err)
-		os.Exit(1)
+	} else {
+		// Embed the SHA256 digest only for appimages which are not having
+		// update information.
+		// Embed SHA256 digest into '.sha256_sig' section if it exists
+		// This is not part of the AppImageSpec yet, but in the future we will want to put this into the AppImageSpec:
+		// If an AppImage is not signed, it should have the SHA256 digest in the '.sha256_sig' section; this might
+		// eventually remove the need for an extra '.digest_md5' section and hence simplify the format
+		digest := helpers.CalculateSHA256Digest(target)
+		err = helpers.EmbedStringInSegment(target, ".sha256_sig", digest)
+		if err != nil {
+			helpers.PrintError("EmbedStringInSegment", err)
+			os.Exit(1)
+		}
 	}
 
 	// TODO: calculate and embed MD5 digest (in case we want to use it)


### PR DESCRIPTION
Fixes #68 

Previously, appimages generated with go-appimage contained the sha-signature
which keeps changing across builds. Hence, AppImageUpdate could not verify the new
appimage against the old version. The sha-signature can now be included only on
non-production builds, i.e those appimages which does not include updateinformation