### PR TITLE
Quick and dirty patch to stop uca.xml overwriting

### DIFF
--- a/src/appimaged/filemanager.go
+++ b/src/appimaged/filemanager.go
@@ -70,7 +70,7 @@ Name=Make executable
     <unique-id>` + XFCEThunarActionUniqueID + `</unique-id>
     <command>` + arg0abs + ` %f</command>
     <description>Update the AppImage</description>
-    <patterns>*AppImage,*.appimage</patterns>
+    <patterns>*.AppImage;*.appimage</patterns>
     <other-files/>
     <directories/>
 </action>

--- a/src/appimaged/filemanager.go
+++ b/src/appimaged/filemanager.go
@@ -62,10 +62,12 @@ Icon=utilities-terminal
 Name=Make executable
 `
 
+	XFCEThunarActionUniqueID := `1573903056061608-1`
+
 	XFCEThunarAction := `<action>
     <icon>terminal</icon>
     <name>Update</name>
-    <unique-id>1573903056061608-1</unique-id>
+    <unique-id>` + XFCEThunarActionUniqueID + `</unique-id>
     <command>` + arg0abs + ` %f</command>
     <description>Update the AppImage</description>
     <patterns>*AppImage,*.appimage</patterns>
@@ -131,7 +133,7 @@ Name=Make executable
 
 		for ucaFileReader.Scan() { // We read the file line by line checking for our unique-id
 			curLine := ucaFileReader.Text()
-			if strings.Contains(curLine, "1573903056061608-1") { // If we find our action, there's nothing to be done so we return
+			if strings.Contains(curLine, XFCEThunarActionUniqueID) { // If we find our action, there's nothing to be done so we return
 				return
 			}
 		}

--- a/src/appimaged/filemanager.go
+++ b/src/appimaged/filemanager.go
@@ -73,8 +73,7 @@ Name=Make executable
     <patterns>*.AppImage;*.appimage</patterns>
     <other-files/>
     <directories/>
-</action>
-`
+</action>`
 
 	XFCEThunarUCABody := `<?xml version="1.0" encoding="UTF-8"?>
 <actions>


### PR DESCRIPTION
This commit adds a patch to stop Thunar's uca.xml file being overwritten on XFCE. Fixes #95 

This patch introduces a check to see if our action is present in the user's uca.xml, and in case it isn't, appends it to the beginning of the <actions> section of uca.xml.

I apologize if the quality of the code isn't good, this is my first time writing Go and I'm mainly a C++ programmer :(