### PR TITLE
Stop superfluous copy of ld-linux so

### DIFF
--- a/src/appimagetool/appdirtool.go
+++ b/src/appimagetool/appdirtool.go
@@ -412,7 +412,12 @@ func deployElf(lib string, appdir helpers.AppDir, err error) {
 			return
 		}
 	}
-	
+
+	if strings.HasPrefix(filepath.Base(lib), "ld-") == true {
+		log.Println("deployElf: Ignore", lib, "because it is already deployed...")
+		return
+	}
+
 	log.Println("Working on", lib, "(TODO: Remove this message)")
 	if strings.HasPrefix(lib, appdir.Path) == false { // Do not copy if it is already in the AppDir
 		libTargetPath := appdir.Path + "/" + lib


### PR DESCRIPTION
deployELF function was copying ld-linux so from locations other than /lib64/. Use a similar routine in deployELF as is used in patchRpathsInElf to prohibit ld-linux so processing. #76 