### PR TITLE
Fix error "Invalid desktop file" by adding an Exec key to trash action

### DIFF
--- a/src/appimaged/desktop.go
+++ b/src/appimaged/desktop.go
@@ -123,6 +123,9 @@ func writeDesktopFile(ai AppImage) {
 		} else if helpers.IsCommandAvailable("kioclient") {
 			// Of course KDE has its own facility for doing the exact same thing
 			cfg.Section("Desktop Action Trash").Key("Exec").SetValue("kioclient move \"" + ai.path + "\" trash:/")
+		} else {
+			// Provide a fallback shell command to prevent parser errors on other desktops
+			cfg.Section("Desktop Action Trash").Key("Exec").SetValue("mv \"" + ai.path + "\" ~/.local/share/Trash/")
 		}
 
 		// Add OpenPortableHome action


### PR DESCRIPTION
.. for desktop environments other than KDE or Gnome.

Otherwise, an error notification will be shown and ~/.xsession-errors
will contain a similar message:

ERROR desktop-file-validate: exit status 1
/home/user/.local/share/applications/appimagekit_d2a6a5eadca61238f89301b8918634f3.desktop: error: required key "Exec" in group "Desktop Action Trash" is not present
ERROR: Desktop file contains errors. Please fix them. Please see https://standards.freedesktop.org/desktop-entry-spec/1.0
2020/11/23 17:33:53 ----------------------------
2020/11/23 17:33:53 Notification:
2020/11/23 17:33:53 Invalid desktop file