### PR TITLE
ci: Add GitHub Actions CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,182 @@
+name: Build
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+
+  build-appimagetool:
+    name: Pre-deploy tests ${{ matrix.app }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [appimagetool]
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build
+      shell: bash
+      run: |
+        go build -v -trimpath -ldflags="-s -w" ./src/${{ matrix.app }}
+        mv ./${{ matrix.app }} ./${{ matrix.app }}-$(go env GOHOSTARCH)
+        # export the ARCHITECTURE
+        export ARCHITECTURE=x86_64
+        mkdir -p ${{ matrix.app }}.AppDir/usr/bin
+        
+        if [[ "${{ matrix.app }}" != "appimaged" ]]; then
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/desktop-file-validate-$ARCHITECTURE -O desktop-file-validate )
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/mksquashfs-$ARCHITECTURE -O mksquashfs )
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/patchelf-$ARCHITECTURE -O patchelf )
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/AppImage/AppImageKit/releases/download/continuous/runtime-$ARCHITECTURE )
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh -O uploadtool )
+        fi
+        if [[ "${{ matrix.app }}" != "appimagetool" ]]; then
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/bsdtar-$ARCHITECTURE -O bsdtar )
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/unsquashfs-$ARCHITECTURE -O unsquashfs )
+        fi
+        chmod +x ${{ matrix.app }}.AppDir/usr/bin/*
+        cp ${{ matrix.app }}-$(go env GOHOSTARCH) ${{ matrix.app }}.AppDir/usr/bin/${{ matrix.app }}
+        ( cd ${{ matrix.app }}.AppDir/ ; ln -s usr/bin/${{ matrix.app }} AppRun)
+        cp data/appimage.png ${{ matrix.app }}.AppDir/
+        cat > ${{ matrix.app }}.AppDir/${{ matrix.app }}.desktop <<\EOF
+        [Desktop Entry]
+        Type=Application
+        Name=${{ matrix.app }}
+        Exec=${{ matrix.app }}
+        Comment=${{ matrix.app }} - tool to generate AppImages from AppDirs
+        Icon=appimage
+        Categories=Development;
+        Terminal=true
+        EOF
+        if [[ "${{ matrix.app }}" == "appimagetool" ]]; then
+          ln -s ${{ matrix.app }}.AppDir/usr/bin/* .
+          PATH="${{ matrix.app }}.AppDir/usr/bin/:$PATH" ./appimagetool-* ./${{ matrix.app}}.AppDir  || true
+        else
+          chmod +x ./appimage.AppImage
+          ./appimage.AppImage ./${{ matrix.app}}.AppDir || true
+        fi
+        rm -rf ./appimage.AppImage
+        mkdir dist
+        mv *.AppImage dist
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: ${{ matrix.app }}-deploy.AppImage
+        path: dist
+
+
+  build-others:
+    name: Build ${{ matrix.app }}
+    needs: build-appimagetool
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [appimagetool, appimaged]
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+        
+    - name: Download a prebuilt appimagetool 
+      if: ${{ matrix.app }} != appimagetool
+      uses: actions/download-artifact@v1
+      with:
+        name: appimagetool-deploy.AppImage
+
+    - name: Build
+      shell: bash
+      run: |
+        go build -v -trimpath -ldflags="-s -w" ./src/${{ matrix.app }}
+        mv ./${{ matrix.app }} ./${{ matrix.app }}-$(go env GOHOSTARCH)
+        # export the ARCHITECTURE
+        export ARCHITECTURE=x86_64
+        mkdir -p ${{ matrix.app }}.AppDir/usr/bin
+        
+        if [[ "${{ matrix.app }}" != "appimaged" ]]; then
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/desktop-file-validate-$ARCHITECTURE -O desktop-file-validate )
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/mksquashfs-$ARCHITECTURE -O mksquashfs )
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/patchelf-$ARCHITECTURE -O patchelf )
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/AppImage/AppImageKit/releases/download/continuous/runtime-$ARCHITECTURE )
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh -O uploadtool )
+        fi
+        if [[ "${{ matrix.app }}" != "appimagetool" ]]; then
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/bsdtar-$ARCHITECTURE -O bsdtar )
+            ( cd ${{ matrix.app }}.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/unsquashfs-$ARCHITECTURE -O unsquashfs )
+        fi
+        chmod +x ${{ matrix.app }}.AppDir/usr/bin/*
+        cp ${{ matrix.app }}-$(go env GOHOSTARCH) ${{ matrix.app }}.AppDir/usr/bin/${{ matrix.app }}
+        ( cd ${{ matrix.app }}.AppDir/ ; ln -s usr/bin/${{ matrix.app }} AppRun)
+        cp data/appimage.png ${{ matrix.app }}.AppDir/
+        cat > ${{ matrix.app }}.AppDir/${{ matrix.app }}.desktop <<\EOF
+        [Desktop Entry]
+        Type=Application
+        Name=${{ matrix.app }}
+        Exec=${{ matrix.app }}
+        Comment=${{ matrix.app }} - tool to generate AppImages from AppDirs
+        Icon=appimage
+        Categories=Development;
+        Terminal=true
+        EOF
+        if [[ "${{ matrix.app }}" == "appimagetool" ]]; then
+          ln -s ${{ matrix.app }}.AppDir/usr/bin/* .
+          PATH="${{ matrix.app }}.AppDir/usr/bin/:$PATH" ./appimagetool-* ./${{ matrix.app}}.AppDir || true  # FIXME: remove this true
+        else
+          # use our own dog food :)
+          chmod +x ./appimagetool-deploy.AppImage/*.AppImage
+          ./appimagetool-deploy.AppImage/*.AppImage ./${{ matrix.app}}.AppDir || true
+        fi
+        rm -rf ./appimage.AppImage
+        mkdir dist
+        mv *.AppImage dist
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: ${{ matrix.app }}-continuous.AppImage
+        path: dist
+
+    - name: Pre Release
+      uses: marvinpinto/action-automatic-releases@latest
+      if: github.ref == 'refs/heads/master' && startsWith(github.ref, 'refs/tags/') != true
+      with:
+        prerelease: true
+        draft: false
+        automatic_release_tag: ${{ matrix.app }}-continuous
+        title: ${{ matrix.app }} Continuous Build
+        files: |
+          ${{ matrix.app }}-continuous.AppImage
+  
+

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 !*.md
 !*.iml
 !*.xml
+!*.yml
 
 # Everything below this line is redundant
 # and may be removed once everything works as intended


### PR DESCRIPTION
Possibly fixes #105 

Right now, it only works for 64-bit builds. Adding `mkappimage` at L93 would automatically configure the actions to build and release mkappimage also.