### PR TITLE
DONTMERGE helpers.Args0() get's it wrong if appimaged is in PATH

### DIFF
--- a/src/appimaged/appimaged.go
+++ b/src/appimaged/appimaged.go
@@ -88,7 +88,7 @@ var candidateDirectories = []string{
 
 func main() {
 
-	thisai.path = helpers.Args0()
+	thisai.path, _ = exec.LookPath(os.Args[0])
 
 	// As quickly as possible go there if we are invoked from the command line with a command
 	takeCareOfCommandlineCommands()


### PR DESCRIPTION
This a glitch I found when I hot-replaced the daemon binary in my VM experiments..
`helpers.Args0` prepends invocation path (cwd) instead of executable location
f.e. instead of /usr/local/bin/appimaged writes /home/user/appimaged into
service file

.. this is what I found to work.. sorry, just a demo patch xD