### PR TITLE
Updated squashfs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/probonopd/go-appimage
 go 1.13
 
 require (
-	github.com/CalebQ42/squashfs v0.3.6
+	github.com/CalebQ42/squashfs v0.3.7
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/acobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249
 	github.com/adrg/xdg v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/CalebQ42/GoAppImage v0.4.0 h1:aF+Y/vyo/RGhoyZEW1CMY6WyRWrZZO4ydsRFAtIGnaY=
 github.com/CalebQ42/GoAppImage v0.4.0/go.mod h1:qHudJKAn/dlkNWNnH4h1YKXp29EZ7Bppsn7sNP2HuvU=
-github.com/CalebQ42/squashfs v0.3.5 h1:EniKQIvaGkPIz/6WebIZGFnEV9Viio6cyRPMJs0B+/Y=
-github.com/CalebQ42/squashfs v0.3.5/go.mod h1:vKz+LDiKqKGDlB6tiykL3rtHdGT+QEPicvoF80S2S0Q=
-github.com/CalebQ42/squashfs v0.3.6 h1:bn2w7YyH++8OHiSmiqsG7FP2p+pizuA3Qo1HJSXSGtU=
-github.com/CalebQ42/squashfs v0.3.6/go.mod h1:vKz+LDiKqKGDlB6tiykL3rtHdGT+QEPicvoF80S2S0Q=
+github.com/CalebQ42/squashfs v0.3.7 h1:qmpnHaCThgdGirlXbYxGv2Qj04VZAl6wQuv2iJkvG6Y=
+github.com/CalebQ42/squashfs v0.3.7/go.mod h1:U5yRHSL3wolsbnO8gvWwBgnXfrFzt5jbJdjNTNkTby8=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/acobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249 h1:fMi9ZZ/it4orHj3xWrM6cLkVFcCbkXQALFUiNtHtCPs=
@@ -74,8 +72,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
-github.com/klauspost/compress v1.11.3 h1:dB4Bn0tN3wdCzQxnS8r06kV74qN/TAfaIS0bVE8h3jc=
-github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.4 h1:kz40R/YWls3iqT9zX9AHN3WoVsrAWVyui5sxuLqiXqU=
+github.com/klauspost/compress v1.11.4/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
@@ -100,8 +98,8 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/otiai10/mint v1.3.2 h1:VYWnrP5fXmz1MXvjuUvcBrXSjGE6xjON+axB/UrpO3E=
 github.com/otiai10/mint v1.3.2/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
-github.com/pierrec/lz4/v4 v4.1.1 h1:cS6aGkNLJr4u+UwaA21yp+gbWN3WJWtKo1axmPDObMA=
-github.com/pierrec/lz4/v4 v4.1.1/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.2 h1:qvY3YFXRQE/XB8MlLzJH7mSzBs74eA2gg52YTk6jUPM=
+github.com/pierrec/lz4/v4 v4.1.2/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -145,8 +143,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
-github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.9 h1:RsKRIA2MO8x56wkkcd3LbtcE/uMszhb6DpRf+3uwa3I=
+github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=

--- a/src/appimaged/desktop.go
+++ b/src/appimaged/desktop.go
@@ -241,7 +241,7 @@ func fixDesktopFile(path string) error {
 		output = bytes.Replace(input, []byte("=`"), []byte("="), -1)
 		output = bytes.Replace(output, []byte("`\n"), []byte("\n"), -1)
 	}
-	output = bytes.ReplaceAll(output, []byte(","), []byte(";"))
+	output = bytes.ReplaceAll(output, []byte("；"), []byte(";"))
 
 	if err = ioutil.WriteFile(path, output, 0755); err != nil {
 		return err

--- a/src/appimaged/desktop.go
+++ b/src/appimaged/desktop.go
@@ -240,10 +240,8 @@ func fixDesktopFile(path string) error {
 	if bytes.Contains(input, []byte("=`")) {
 		output = bytes.Replace(input, []byte("=`"), []byte("="), -1)
 		output = bytes.Replace(output, []byte("`\n"), []byte("\n"), -1)
-		//some issues that appear now that we're using the original .desktop file
-		output = bytes.Replace(output, []byte("\n;\n"), []byte("\n"), -1)
-		output = bytes.Replace(output, []byte("\n; \n"), []byte("\n"), -1)
 	}
+	output = bytes.ReplaceAll(output, []byte(","), []byte(";"))
 
 	if err = ioutil.WriteFile(path, output, 0755); err != nil {
 		return err

--- a/src/goappimage/appimage.go
+++ b/src/goappimage/appimage.go
@@ -77,7 +77,7 @@ func NewAppImage(path string) (*AppImage, error) {
 		var line string
 		line, err = buf.ReadString('\n')
 		if strings.Contains(line, ";") {
-			line = strings.ReplaceAll(line, ";", ",")
+			line = strings.ReplaceAll(line, ";", "；") //replacing it with a fullwidth semicolon (unicode FF1B)
 		}
 		desktop = append(desktop, line...)
 	}

--- a/src/goappimage/appimage.go
+++ b/src/goappimage/appimage.go
@@ -1,6 +1,7 @@
 package goappimage
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"io"
@@ -68,7 +69,20 @@ func NewAppImage(path string) (*AppImage, error) {
 	if err != nil {
 		return nil, err
 	}
-	ai.Desktop, err = ini.Load(desktopFil)
+
+	//cleaning the desktop file so it can be parsed properly
+	var desktop []byte
+	buf := bufio.NewReader(desktopFil)
+	for err == nil {
+		var line string
+		line, err = buf.ReadString('\n')
+		if strings.Contains(line, ";") {
+			line = strings.ReplaceAll(line, ";", ",")
+		}
+		desktop = append(desktop, line...)
+	}
+
+	ai.Desktop, err = ini.Load(desktop)
 	if err == nil {
 		ai.Name = ai.Desktop.Section("Desktop Entry").Key("Name").Value()
 	}

--- a/src/goappimage/archivereader.go
+++ b/src/goappimage/archivereader.go
@@ -209,7 +209,7 @@ func (r *type2Reader) FileReader(filepath string) (io.ReadCloser, error) {
 		if fil.IsDir() {
 			return nil, errors.New("Path is a directory: " + filepath)
 		}
-		return fil, nil
+		return ioutil.NopCloser(fil), nil
 	}
 	filepath, err := r.cleanPath(filepath)
 	filepath = r.SymlinkPathRecursive(filepath)


### PR DESCRIPTION
Should fix #121

I also found a bug with the ini library for desktop files where it wouldn't parse semicolons correctly (such as in categories or keyword sections) and fixed that.