### PR TITLE
Remove trailing quotation mark from chmod

### DIFF
--- a/src/appimaged/README.md
+++ b/src/appimaged/README.md
@@ -18,7 +18,7 @@ rm "$HOME"/.local/share/applications/appimage*
 
 # Download
 wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases -O - | grep "appimaged-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
-chmod +x "appimaged-*.AppImage
+chmod +x appimaged-*.AppImage
 
 # Launch
 ./appimaged-*.AppImage


### PR DESCRIPTION
Executing the original chmod commands just opens a new terminal line that is suspended indefinetely:

```
chmod +x "appimaged-*.AppImage`
>
```
It properly executes without the quotation mark though.

System: Pop!_OS 20.10