### PR TITLE
Add Version to AppImage struct

### DIFF
--- a/src/goappimage/appimage.go
+++ b/src/goappimage/appimage.go
@@ -90,11 +90,7 @@ func NewAppImage(path string) (*AppImage, error) {
 	if ai.Name == "" {
 		ai.Name = ai.calculateNiceName()
 	}
-	// If key "X-AppImage-Version" not set (likely), use "Version", which unfortunately is commonly set wrong
-	if ai.Version == "" {
-		ai.Version = ai.Desktop.Section("Desktop Entry").Key("Version").Value()
-	}
-	// Finally, if somehow the desktop file got through without that being specified, resort to just setting it to 1
+	//If key "X-AppImage-Version" not set (likely), resort to just setting it to 1
 	if ai.Version == "" {
 		ai.Version = "1.0"
 	}

--- a/src/goappimage/appimage.go
+++ b/src/goappimage/appimage.go
@@ -32,6 +32,7 @@ type AppImage struct {
 	Path    string
 	// updateInformation string TODO: add update stuff
 	Name      string
+	Version   string
 	offset    int64
 	imageType int
 }
@@ -84,9 +85,18 @@ func NewAppImage(path string) (*AppImage, error) {
 	ai.Desktop, err = ini.Load(desktop)
 	if err == nil {
 		ai.Name = ai.Desktop.Section("Desktop Entry").Key("Name").Value()
+		ai.Version = ai.Desktop.Section("Desktop Entry").Key("X-AppImage-Version").Value()
 	}
 	if ai.Name == "" {
 		ai.Name = ai.calculateNiceName()
+	}
+	// If key "X-AppImage-Version" not set (likely), use "Version", which unfortunately is commonly set wrong
+	if ai.Version == "" {
+		ai.Version = ai.Desktop.Section("Desktop Entry").Key("Version").Value()
+	}
+	// Finally, if somehow the desktop file got through without that being specified, resort to just setting it to 1
+	if ai.Version == "" {
+		ai.Version = "1.0"
 	}
 	return &ai, nil
 }


### PR DESCRIPTION
Pull the version out of the AppImage desktop file, perferring X-AppImage-Version since a lot of people are lazy and don't fill out the normal Version key correctly.