### PR TITLE
appimaged: Allow missing notification daemon

### DIFF
--- a/src/appimaged/notification.go
+++ b/src/appimaged/notification.go
@@ -167,7 +167,7 @@ func sendDesktopNotification(title string, body string, durationms int32) {
 		log.Println("xxxxxxxxxxxxxxxxxxxx ERROR: notification:", call.Err)
 		// Sometimes we get here: "read unix @->/run/user/999/bus: EOF"
 		// means that we are not using PrivateConnection?
-        return
+		return
 	}
 
 }

--- a/src/appimaged/notification.go
+++ b/src/appimaged/notification.go
@@ -167,7 +167,7 @@ func sendDesktopNotification(title string, body string, durationms int32) {
 		log.Println("xxxxxxxxxxxxxxxxxxxx ERROR: notification:", call.Err)
 		// Sometimes we get here: "read unix @->/run/user/999/bus: EOF"
 		// means that we are not using PrivateConnection?
-		os.Exit(111)
+        return
 	}
 
 }


### PR DESCRIPTION
The previous exit branch is reached when the system is missing an notification deamon. 

Not all systems have notification daemons and there's no reason to stop execution in such a scenario. 