### PR TITLE
Fix removal instructions for appimaged

### DIFF
--- a/src/appimaged/README.md
+++ b/src/appimaged/README.md
@@ -28,8 +28,9 @@ chmod +x ~/Applications/appimaged-*.AppImage
 ## Removal
 
 ```
+systemctl --user disable appimaged.service || true
 systemctl --user stop appimaged.service || true
-sudo rm /etc/systemd/user/appimaged.service
+rm ~/.config/systemd/user/appimaged.service
 rm ~/.local/share/applications/appimagekit*.desktop
 rm ~/Applications/appimaged-*-x86_64.AppImage
 ```


### PR DESCRIPTION
Fixes #185 

This could alternatively use a single `systemctl --user disable --now appimaged.service` command which uses `--now` flag that [was added in systemd v220](https://lists.freedesktop.org/archives/systemd-devel/2015-May/032147.html) but that was released in 2015 so I'm not sure if it's portable enough.