### PR TITLE
Fix #192

### DIFF
--- a/src/appimaged/desktop.go
+++ b/src/appimaged/desktop.go
@@ -93,7 +93,12 @@ func writeDesktopFile(ai AppImage) {
 	// so that renaming the file in the file manager results in a changed name in the menu
 	// FIXME: If the thumbnail is not generated here but by another external thumbnailer, it may not be fast enough
 	time.Sleep(1 * time.Second)
-	cfg.Section("Desktop Entry").Key("Exec").SetValue(arg0abs + " wrap \"" + ai.Path + "\"") // Resolve to a full path
+	add := ""
+	args, err := ai.Args()
+	if err == nil {
+		add = " " + strings.Join(args, " ")
+	}
+	cfg.Section("Desktop Entry").Key("Exec").SetValue(arg0abs + " wrap \"" + ai.Path + "\"" + add) // Resolve to a full path
 	cfg.Section("Desktop Entry").Key(ExecLocationKey).SetValue(ai.Path)
 	cfg.Section("Desktop Entry").Key("TryExec").SetValue(arg0abs) // Resolve to a full path
 	// For icons, use absolute paths. This way icons start working

--- a/src/goappimage/appimage.go
+++ b/src/goappimage/appimage.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -205,6 +206,27 @@ func (ai AppImage) Icon() (io.ReadCloser, string, error) {
 		}
 	}
 	return nil, "", errors.New("Cannot find the AppImage's icon: " + icon)
+}
+
+func (ai AppImage) Args() ([]string, error) {
+	if ai.Desktop == nil {
+		return nil, errors.New("desktop file wasn't parsed")
+	}
+	var exec = ai.Desktop.Section("Desktop Entry").Key("Exec").Value()
+	fmt.Println("exec:", exec)
+	if exec == "" {
+		return nil, errors.New("exec key not present")
+	}
+	if strings.HasPrefix(exec, "\"") {
+		if strings.Contains(exec[1:], "\"") {
+			exec = exec[1 : strings.Index(exec[1:], "\"")+1]
+		}
+	}
+	spl := strings.Split(exec, " ")
+	if len(spl) <= 1 {
+		return make([]string, 0), nil
+	}
+	return spl[1:], nil
 }
 
 func runCommand(cmd *exec.Cmd) (bytes.Buffer, error) {


### PR DESCRIPTION
Fixes #192 by adding arguments that are present in the AppImage's desktop file to the generated desktop file. Also a partial fix for #183.