### PR TITLE
Allow to statically link Go programs, even with cgo

### DIFF
--- a/.github/workflows/build_pr.yaml
+++ b/.github/workflows/build_pr.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-all:
     name: Build for all architectures
-    runs-on: ubuntu-18.04
+    runs-on: alpine-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Go

--- a/.github/workflows/build_pr.yaml
+++ b/.github/workflows/build_pr.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-all:
     name: Build for all architectures
-    runs-on: alpine-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Go

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-all:
     name: Build for all architectures
-    runs-on: alpine-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Go

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-all:
     name: Build for all architectures
-    runs-on: ubuntu-18.04
+    runs-on: alpine-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Go

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -80,7 +80,7 @@ build () {
   esac
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
-  CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-fno-PIC -no-pie -static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  CGO_LDFLAGS="-no-pie" CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -80,7 +80,7 @@ build () {
   esac
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
-  CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-no-pie -linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-fno-PIC -no-pie -static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -80,8 +80,7 @@ build () {
   esac
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
-  # CC=/usr/local/musl/bin/musl-gcc go build ...
-  go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -203,7 +203,7 @@ if [ ! -e "/usr/local/musl/bin/musl-gcc" ]; then
   wget -c -q http://www.musl-libc.org/releases/musl-1.1.10.tar.gz
   tar -xvf musl-*.tar.gz
   cd musl-*/
-  ./configure
+  ./configure --enable-gcc-wrapper
   make -j$(nproc)
   sudo make install
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -80,7 +80,7 @@ build () {
   esac
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
-  CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-no-pie -linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin


### PR DESCRIPTION
Statically compile Go programs, even with cgo, using musl libc, like this:

```
wget -c -q http://www.musl-libc.org/releases/musl-1.1.10.tar.gz
tar -xvf musl-*.tar.gz
cd musl-*/
./configure
make -j4
sudo make install
CC=/usr/local/musl/bin/musl-gcc go build --ldflags '-linkmode external -extldflags "-static"' hello.go
```

Credits: https://honnef.co/posts/2015/06/statically_compiled_go_programs__always__even_with_cgo__using_musl/

We can probably get around compiling musl libc by using an Alpine Linux container rather than an Ubuntu one in the first place.