### PR TITLE
Allow to statically link Go programs, even with cgo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run build script
-      run: ./scripts/build.sh -a amd64,arm64
+      run: ./scripts/build.sh -a amd64
     - name: Upload to GitHub Artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run build script
-      run: ./scripts/build.sh -a amd64,386,arm64,arm
+      run: ./scripts/build.sh -a amd64,arm64
     - name: Upload to GitHub Artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: 1.18
     - uses: actions/cache@v2
       with:
         path: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,11 @@ name: Build All Architectures
 on:
   workflow_dispatch:
   push:
+    branches:    
+      - 'master'
+    paths-ignore:
+      - '.idea/..'
+      - 'docs/**'
   pull_request:
     paths-ignore:
       - '.idea/..'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run build script
-      run: ./scripts/build.sh -a amd64
+      run: ./scripts/build.sh -a amd64,386,arm64,arm
     - name: Upload to GitHub Artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.19
     - uses: actions/cache@v2
       with:
         path: |

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,6 +93,7 @@ build () {
   echo BUILDARCH: $BUILDARCH
   echo GOGCCFLAGS: $GOGCCFLAGS
   echo CC: $CC
+  export PATH=$(readlink -f ../zig-linux-*/):$PATH
   which zig
   zig env
   CGO_LDFLAGS="-no-pie" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
@@ -215,8 +216,6 @@ fi
 if [ -n "$(which zig)" ]; then
   wget -c -q "https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.2112+0df28f9d4.tar.xz"
   tar xf zig-linux-*-*.tar.xz
-  export PATH=$(readlink -f ./zig-linux-*/):$PATH
-  which zig
 fi
 
 if [ -z $BUILDTOOL ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -97,7 +97,7 @@ build () {
   zig env
   # CGO_LDFLAGS="-no-pie" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # CGO_ENABLED=1 go build --tags extended  $PROJECT/src/$PROG
-  CGO_ENABLED=1 go build -o $BUILDDIR -v -trimpath -ldflags="-v -linkmode=external -s -w -X main.commit=$COMMIT" --tags extended $PROJECT/src/$PROG
+  CGO_ENABLED=1 go build -o $BUILDDIR -v -trimpath -ldflags="-v -linkmode=external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -87,6 +87,9 @@ build () {
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
   go clean
+  echo ARCH: $ARCH
+  echo GOARCH: $GOARCH
+  echo GOHOSTARCH: $GOHOSTARCH
   CGO_LDFLAGS="-no-pie" CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -73,10 +73,10 @@ set_arch_env () {
 build () {
   set_arch_env $1
   case $1 in
-    amd64) local GOGCCFLAGS=-m64;;
-    386) local GOGCCFLAGS=-m32;;
-    arm64) local GOGCCFLAGS=-m64;;
-    arm) local GOGCCFLAGS=-m32;;
+    amd64) export GOGCCFLAGS=-m64;;
+    386) export GOGCCFLAGS=-m32;;
+    arm64) export GOGCCFLAGS=-m64;;
+    arm) export GOGCCFLAGS=-m32;;
   esac
   case $1 in
     amd64) local ARCH=x86_64;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,7 +93,6 @@ build () {
   echo BUILDARCH: $BUILDARCH
   echo GOGCCFLAGS: $GOGCCFLAGS
   echo CC: $CC
-  export PATH=$(readlink -f $HOME/zig-linux-*/):$PATH
   which zig
   zig env
   CGO_LDFLAGS="-no-pie" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
@@ -213,11 +212,11 @@ if [ $GITHUB_ACTIONS ]; then
 fi
 
 # Install zig, it comes with musl libc
-if [ ! -e $HOME/zig-linux-*/zig ]; then
-  cd $HOME
+if [ ! -e /usr/local/bin/zig ]; then
   wget -c -q "https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.2112+0df28f9d4.tar.xz"
   tar xf zig-linux-*-*.tar.xz
-  cd -
+  sudo mv zig-linux-*/* /usr/local/bin/
+  which zig
 fi
 
 if [ -z $BUILDTOOL ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -82,7 +82,7 @@ build () {
     amd64) export ZIGTARGET=x86_64-linux-musl;;
     386) export ZIGTARGET=i386-linux-musl;;
     arm64) export ZIGTARGET=aarch64-linux-musl;;
-    arm) export ZIGTARGET=arm-linux-musl;;
+    arm) export ZIGTARGET=arm-linux-musleabihf;;
   esac
   export CC="zig cc -target $ZIGTARGET"
   local PROG=$2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -73,6 +73,12 @@ set_arch_env () {
 build () {
   set_arch_env $1
   case $1 in
+    amd64) local GOGCCFLAGS=-m64;;
+    386) local GOGCCFLAGS=-m32;;
+    arm64) local GOGCCFLAGS=-m64;;
+    arm) local GOGCCFLAGS=-m32;;
+  esac
+  case $1 in
     amd64) local ARCH=x86_64;;
     386) local ARCH=i686;;
     arm64) local ARCH=aarch64;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -95,7 +95,8 @@ build () {
   echo CC: $CC
   which zig
   zig env
-  CGO_LDFLAGS="-no-pie" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  # CGO_LDFLAGS="-no-pie" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  CGO_ENABLED=1 go build --tags extended  $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -95,7 +95,7 @@ build () {
   echo CC: $CC
   which zig
   zig env
-  CGO_ENABLED=1 go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode=external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  CGO_ENABLED=1 go build -o $BUILDDIR -v -trimpath -ldflags="-extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -221,7 +221,7 @@ if [ ! -e "/usr/local/musl/bin/musl-gcc" ]; then
   sudo make install
 fi
 
-if [ ! -e /usr/local/bin/zig ]; then
+if [ -n "$(which zig)" ]; then
   wget -c -q "https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.2112+0df28f9d4.tar.xz"
   tar xf zig-linux-*-*.tar.xz
   export PATH=$(readlink -f ./zig-linux-*/):$PATH

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -97,7 +97,7 @@ build () {
   zig env
   # CGO_LDFLAGS="-no-pie" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # CGO_ENABLED=1 go build --tags extended  $PROJECT/src/$PROG
-  CGO_ENABLED=1 go build -ldflags '-v -linkmode=external' --tags extended $PROJECT/src/$PROG
+  CGO_ENABLED=1 go build -o $BUILDDIR -v -trimpath -ldflags="-v -linkmode=external -s -w -X main.commit=$COMMIT" --tags extended $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -96,7 +96,8 @@ build () {
   which zig
   zig env
   # CGO_LDFLAGS="-no-pie" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
-  CGO_ENABLED=1 go build --tags extended  $PROJECT/src/$PROG
+  # CGO_ENABLED=1 go build --tags extended  $PROJECT/src/$PROG
+  CGO_ENABLED=1 go build -ldflags '-v -linkmode=external' --tags extended $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -84,7 +84,7 @@ build () {
     arm64) export ZIGTARGET=aarch64-linux-musl;;
     arm) export ZIGTARGET=arm-linux-musleabihf;;
   esac
-  export CC="zig cc -Wl,--no-gc-sections -target $ZIGTARGET"
+  export CC="zig cc -target $ZIGTARGET"
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
   echo ARCH: $ARCH
@@ -95,7 +95,8 @@ build () {
   echo CC: $CC
   which zig
   zig env
-  CGO_ENABLED=1 go build -o $BUILDDIR -v -trimpath -ldflags="-extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  CGO_ENABLED=1 go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode=external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  strip $PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -86,6 +86,7 @@ build () {
   esac
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
+  go clean ./...
   rm -rf /tmp/go-link-* || true
   CGO_LDFLAGS="-no-pie" CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -84,6 +84,7 @@ build () {
     arm64) export ZIGTARGET=aarch64-linux-musleabi;;
     arm) export ZIGTARGET=arm-linux-musleabihf;;
   esac
+  export CC=zig cc -target $ZIGTARGET
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
   # go clean
@@ -92,8 +93,9 @@ build () {
   echo GOHOSTARCH: $GOHOSTARCH
   echo BUILDARCH: $BUILDARCH
   echo GOGCCFLAGS: $GOGCCFLAGS
-  echo ZIGTARGET: $ZIGTARGET
-  CGO_LDFLAGS="-no-pie" CC="zig cc -target $ZIGTARGET" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  echo CC: $CC
+  which zig
+  CGO_LDFLAGS="-no-pie" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,7 +93,6 @@ build () {
   echo BUILDARCH: $BUILDARCH
   echo GOGCCFLAGS: $GOGCCFLAGS
   echo ZIGTARGET: $ZIGTARGET
-  export PATH=$(readlink -f ./zig-linux-*/):$PATH
   CGO_LDFLAGS="-no-pie" CC="zig cc -target $ZIGTARGET" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
@@ -225,6 +224,8 @@ fi
 if [ ! -e /usr/local/bin/zig ]; then
   wget -c -q "https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.2112+0df28f9d4.tar.xz"
   tar xf zig-linux-*-*.tar.xz
+  export PATH=$(readlink -f ./zig-linux-*/):$PATH
+  which zig
 fi
 
 if [ -z $BUILDTOOL ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -86,8 +86,7 @@ build () {
   esac
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
-  go clean ./...
-  rm -rf /tmp/go-link-* || true
+  go clean
   CGO_LDFLAGS="-no-pie" CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,7 +93,7 @@ build () {
   echo BUILDARCH: $BUILDARCH
   echo GOGCCFLAGS: $GOGCCFLAGS
   echo CC: $CC
-  export PATH=$HOME/zig-linux-*/:$PATH
+  export PATH=$(readlink -f $HOME/zig-linux-*/):$PATH
   which zig
   zig env
   CGO_LDFLAGS="-no-pie" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -95,9 +95,7 @@ build () {
   echo CC: $CC
   which zig
   zig env
-  # CGO_LDFLAGS="-no-pie" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
-  # CGO_ENABLED=1 go build --tags extended  $PROJECT/src/$PROG
-  CGO_ENABLED=1 go build -o $BUILDDIR -v -trimpath -ldflags="-v -linkmode=external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  CGO_ENABLED=1 go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode=external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -80,7 +80,7 @@ build () {
   esac
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
-  go build -o $BUILDDIR -v -trimpath -ldflags="-s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  CGO_LDFLAGS="-no-pie" CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin
@@ -193,7 +193,19 @@ fi
 # Install dependencies if needed
 if [ $GITHUB_ACTIONS ]; then
   sudo apt-get update
-  sudo apt-get install --yes wget file gcc
+  sudo apt-get install --yes wget file
+fi
+
+# Allow to statically link Go programs, even with cgo, using musl libc, like this:
+# CC=/usr/local/musl/bin/musl-gcc go build --ldflags '-linkmode external -extldflags "-static"' hello.go
+# https://honnef.co/posts/2015/06/statically_compiled_go_programs__always__even_with_cgo__using_musl/
+if [ ! -e "/usr/local/musl/bin/musl-gcc" ]; then
+  wget -c -q http://www.musl-libc.org/releases/musl-1.1.10.tar.gz
+  tar -xvf musl-*.tar.gz
+  cd musl-*/
+  ./configure --enable-gcc-wrapper
+  make -j$(nproc)
+  sudo make install
 fi
 
 if [ -z $BUILDTOOL ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -84,7 +84,7 @@ build () {
     arm64) export ZIGTARGET=aarch64-linux-musl;;
     arm) export ZIGTARGET=arm-linux-musleabihf;;
   esac
-  export CC="zig cc -target $ZIGTARGET"
+  export CC="zig cc -Wl,--no-gc-sections -target $ZIGTARGET"
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
   echo ARCH: $ARCH

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -81,8 +81,8 @@ build () {
   case $1 in
     amd64) export ZIGTARGET=x86_64-linux-musl;;
     386) export ZIGTARGET=i386-linux-musl;;
-    arm64) export ZIGTARGET=aarch64-linux-musleabi;;
-    arm) export ZIGTARGET=arm-linux-musleabihf;;
+    arm64) export ZIGTARGET=aarch64-linux-musl;;
+    arm) export ZIGTARGET=arm-linux-musl;;
   esac
   export CC="zig cc -target $ZIGTARGET"
   local PROG=$2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -211,18 +211,7 @@ if [ $GITHUB_ACTIONS ]; then
   sudo apt-get install --yes wget file
 fi
 
-# Allow to statically link Go programs, even with cgo, using musl libc, like this:
-# CC=/usr/local/musl/bin/musl-gcc go build --ldflags '-linkmode external -extldflags "-static"' hello.go
-# https://honnef.co/posts/2015/06/statically_compiled_go_programs__always__even_with_cgo__using_musl/
-if [ ! -e "/usr/local/musl/bin/musl-gcc" ]; then
-  wget -c -q http://www.musl-libc.org/releases/musl-1.1.10.tar.gz
-  tar -xvf musl-*.tar.gz
-  cd musl-*/
-  ./configure --enable-gcc-wrapper
-  make -j$(nproc)
-  sudo make install
-fi
-
+# Install zig, it comes with musl libc
 if [ -n "$(which zig)" ]; then
   wget -c -q "https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.2112+0df28f9d4.tar.xz"
   tar xf zig-linux-*-*.tar.xz

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -73,12 +73,6 @@ set_arch_env () {
 build () {
   set_arch_env $1
   case $1 in
-    amd64) export GOGCCFLAGS=-m64;;
-    386) export GOGCCFLAGS=-m32;;
-    arm64) export GOGCCFLAGS=-m64;;
-    arm) export GOGCCFLAGS=-m32;;
-  esac
-  case $1 in
     amd64) local ARCH=x86_64;;
     386) local ARCH=i686;;
     arm64) local ARCH=aarch64;;
@@ -86,7 +80,7 @@ build () {
   esac
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
-  go clean
+  # go clean
   echo ARCH: $ARCH
   echo GOARCH: $GOARCH
   echo GOHOSTARCH: $GOHOSTARCH

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -96,7 +96,9 @@ build () {
   which zig
   zig env
   CGO_ENABLED=1 go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode=external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
-  strip $PROG
+  ls -lh $PROG
+  file $PROG
+  strip $PROG || true
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -80,6 +80,7 @@ build () {
   esac
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
+  rm -rf /tmp/go-link-* || true
   CGO_LDFLAGS="-no-pie" CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -90,6 +90,8 @@ build () {
   echo ARCH: $ARCH
   echo GOARCH: $GOARCH
   echo GOHOSTARCH: $GOHOSTARCH
+  echo BUILDARCH: $BUILDARCH
+  echo GOGCCFLAGS: $GOGCCFLAGS
   CGO_LDFLAGS="-no-pie" CC=/usr/local/musl/bin/musl-gcc go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -84,10 +84,9 @@ build () {
     arm64) export ZIGTARGET=aarch64-linux-musleabi;;
     arm) export ZIGTARGET=arm-linux-musleabihf;;
   esac
-  export CC=zig cc -target $ZIGTARGET
+  export CC="zig cc -target $ZIGTARGET"
   local PROG=$2
   CLEANUP+=($BUILDDIR/$PROG-$ARCH.AppDir)
-  # go clean
   echo ARCH: $ARCH
   echo GOARCH: $GOARCH
   echo GOHOSTARCH: $GOHOSTARCH
@@ -95,6 +94,7 @@ build () {
   echo GOGCCFLAGS: $GOGCCFLAGS
   echo CC: $CC
   which zig
+  zig env
   CGO_LDFLAGS="-no-pie" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,7 +93,7 @@ build () {
   echo BUILDARCH: $BUILDARCH
   echo GOGCCFLAGS: $GOGCCFLAGS
   echo CC: $CC
-  export PATH=$(readlink -f ../zig-linux-*/):$PATH
+  export PATH=$HOME/zig-linux-*/:$PATH
   which zig
   zig env
   CGO_LDFLAGS="-no-pie" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
@@ -213,9 +213,11 @@ if [ $GITHUB_ACTIONS ]; then
 fi
 
 # Install zig, it comes with musl libc
-if [ -n "$(which zig)" ]; then
+if [ ! -e $HOME/zig-linux-*/zig ]; then
+  cd $HOME
   wget -c -q "https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.2112+0df28f9d4.tar.xz"
   tar xf zig-linux-*-*.tar.xz
+  cd -
 fi
 
 if [ -z $BUILDTOOL ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,7 +93,8 @@ build () {
   echo BUILDARCH: $BUILDARCH
   echo GOGCCFLAGS: $GOGCCFLAGS
   echo ZIGTARGET: $ZIGTARGET
-  CGO_LDFLAGS="-no-pie" CC="$(readlink -f ./zig-linux-*/zig) cc -target $ZIGTARGET" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
+  export PATH=$(readlink -f ./zig-linux-*/):$PATH
+  CGO_LDFLAGS="-no-pie" CC="zig cc -target $ZIGTARGET" go build -o $BUILDDIR -v -trimpath -ldflags="-linkmode external -extldflags \"-static\" -s -w -X main.commit=$COMMIT" $PROJECT/src/$PROG
   # common appimage steps
   rm -rf $BUILDDIR/$PROG-$ARCH.AppDir || true
   mkdir -p $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin
@@ -221,9 +222,9 @@ if [ ! -e "/usr/local/musl/bin/musl-gcc" ]; then
   sudo make install
 fi
 
-if [ ! -e ./zig-linux-*/zig ]; then
+if [ ! -e /usr/local/bin/zig ]; then
   wget -c -q "https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.2112+0df28f9d4.tar.xz"
-  tar xf zig-linux-x86_64-*.tar.xz
+  tar xf zig-linux-*-*.tar.xz
 fi
 
 if [ -z $BUILDTOOL ]; then


### PR DESCRIPTION
Use [zig](https://ziglang.org/) as a cc substitute to statically link Go programs, even with cgo, using [musl libc](https://www.musl-libc.org/). Doing it this way has the advantage that no Docker container or chroots are needed for building multiple architectures.

Continuation of https://github.com/probonopd/go-appimage/pull/203