### PR TITLE
Added support for watchfolders.conf

### DIFF
--- a/src/appimaged/README.md
+++ b/src/appimaged/README.md
@@ -48,6 +48,8 @@ Folders being watched for AppImage files:
 * ~/Downloads
 * $PATH, which frequently includes /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin, /usr/local/sbin, and other locations
 
+Folders may be overridden in ~/.config/appimaged/watchfolders.conf or /etc/appimaged/watchfolders.conf
+
 https://github.com/probonopd/go-appimage/releases/tag/continuous has builds for 32-bit Intel, 32-bit ARM (e.g., Raspberry Pi), and 64-bit ARM.
 
 ## Features


### PR DESCRIPTION
Added search for ~/config/appimaged/watchfolders.conf
and /etc/appimaged/watchfolders.conf
(in that order).

If present, the folders identified in the watchfolders.conf are used in preference to the hard coded candidateDirectories list.

The watchfolders.conf file expects to have a list of folders in it (one per line).
Lines starting with # are ignored
~/ is parsed and replaced with <home>/
