### PR TITLE
Bug fixes

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -218,14 +218,6 @@ if [ $GITHUB_ACTIONS ]; then
   sudo apt-get install --yes wget file
 fi
 
-# Install zig, it comes with musl libc
-if [ ! -e /usr/local/bin/zig ]; then
-  wget -c -q "https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.2112+0df28f9d4.tar.xz"
-  tar xf zig-linux-*-*.tar.xz
-  sudo mv zig-linux-*/* /usr/local/bin/
-  which zig
-fi
-
 if [ -z $BUILDTOOL ]; then
   BUILDTOOL=(appimaged appimagetool mkappimage)
 fi
@@ -249,6 +241,17 @@ fi
 mkdir -p $BUILDDIR || true
 cd $BUILDDIR
 
+# Install zig, it comes with musl libc
+if [ ! -e $BUILDDIR/zig ]; then
+  wget -c -q "https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.2112+0df28f9d4.tar.xz"
+  tar xf zig-linux-*.tar.xz
+  rm zig-linux-*.tar.xz
+  mv zig-linux-* zig
+  CLEANUP+=($BUILDDIR/zig)
+fi
+
+PATH=$BUILDDIR/zig:$PATH
+
 # We always want the amd64 appimagetool built first so that other AppImages can be built.
 # If this isn't wanted, we clean it up afterwards
 build amd64 appimagetool
@@ -267,7 +270,7 @@ if [ -z $BUILDINGAPPIMAGETOOL ]; then
   CLEANUP+=($BUILDDIR/appimagetool-$VERSION-x86_64.AppImage)
 fi
 
-if [ -z $DONTCLEAN]; then
+if [ -z $DONTCLEAN ]; then
   for file in ${CLEANUP[@]}; do
     echo $file
     rm -rf $file || true

--- a/src/appimaged/appimaged.go
+++ b/src/appimaged/appimaged.go
@@ -252,15 +252,6 @@ func moveDesktopFiles(ai *AppImage) error {
 	if !integrate {
 		return nil
 	}
-	desktopcachedir := xdg.CacheHome + "/applications/" // FIXME: Do not hardcode here and in other places
-
-	err := os.Rename(desktopcachedir+"/appimagekit_"+ai.md5+".desktop", ai.desktopfilepath)
-	if err != nil {
-		return err
-	}
-	if *verbosePtr {
-		log.Println("main: Moved ", desktopcachedir+"/appimagekit_"+ai.md5+".desktop to", xdg.DataHome+"/applications/")
-	}
 
 	if !ai.startup {
 		// If one single application has been integrated, then the user probably cares about it

--- a/src/appimaged/appwrapper.go
+++ b/src/appimaged/appwrapper.go
@@ -27,6 +27,8 @@ func appwrap() {
 	}
 
 	cmd := exec.Command(os.Args[2], os.Args[3:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
 
 	var out bytes.Buffer
 	cmd.Stderr = &out

--- a/src/appimaged/desktop.go
+++ b/src/appimaged/desktop.go
@@ -58,6 +58,7 @@ func writeDesktopFile(ai AppImage) {
 		desktopRdr, _ := ai.ExtractFileReader("*.desktop")
 		defer desktopRdr.Close()
 		//cleaning the desktop file so it can be parsed properly
+		//TODO: find better desktop file parser that doesn't mistake semicolons for comments.
 		var desktop []byte
 		buf := bufio.NewReader(desktopRdr)
 		for err == nil {
@@ -126,7 +127,7 @@ func writeDesktopFile(ai AppImage) {
 	}
 	// Actions
 
-	var actions []string
+	actions := strings.Split(cfg.Section("Desktop Entry").Key("Actions").String(), "；")
 
 	if isWritable(ai.Path) {
 		// Add "Move to Trash" action

--- a/src/appimaged/desktop.go
+++ b/src/appimaged/desktop.go
@@ -5,7 +5,6 @@ package main
 // but eventually may be rewritten to do things natively in Go.
 
 import (
-	"bufio"
 	"bytes"
 	"log"
 	"os"
@@ -15,7 +14,6 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/adrg/xdg"
 	"github.com/probonopd/go-appimage/internal/helpers"
 	"gopkg.in/ini.v1"
 )
@@ -26,24 +24,14 @@ import (
 // for a while
 func writeDesktopFile(ai AppImage) {
 
-	filename := "appimagekit_" + ai.md5 + ".desktop"
-
 	// log.Println(md5s)
 	// XDG directories
 	// log.Println(xdg.DataHome)
 	// log.Println(xdg.DataDirs)
 	// log.Println(xdg.ConfigHome)
 	// log.Println(xdg.ConfigDirs)
-	desktopcachedir := xdg.CacheHome + "/applications/" // FIXME: Do not hardcode here and in other places
-
-	err := os.MkdirAll(desktopcachedir, os.ModePerm)
-	if err != nil {
-		log.Printf("desktop: %v", err)
-	}
 	// log.Println(xdg.RuntimeDir)
-	var cfg *ini.File
 	ini.PrettyFormat = false
-	startingPoint := false //An easy way to tell if extracting the desktop file worked.
 	arg0abs, err := filepath.Abs(os.Args[0])
 
 	// FIXME: KDE seems to have a problem when the AppImage is on a partition of which the disklabel contains "_"?
@@ -51,41 +39,17 @@ func writeDesktopFile(ai AppImage) {
 	if err != nil {
 		log.Println(err)
 	}
-	if ai.Desktop != nil {
-		//Start with a fresh copy of the desktop file so we don't make edits to ai.Desktop
 
-		desktopRdr, _ := ai.ExtractFileReader("*.desktop")
-		defer desktopRdr.Close()
-		//cleaning the desktop file so it can be parsed properly
-		//TODO: find better desktop file parser that doesn't mistake semicolons for comments.
-		var desktop []byte
-		buf := bufio.NewReader(desktopRdr)
-		for err == nil {
-			var line string
-			line, err = buf.ReadString('\n')
-			if strings.Contains(line, ";") {
-				line = strings.ReplaceAll(line, ";", "；") //replacing it with a fullwidth semicolon (unicode FF1B)
-			}
-			desktop = append(desktop, line...)
-		}
-		cfg, err = ini.Load(desktop)
-		if err == nil {
-			startingPoint = true
-		}
-		//TODO: check if the thumbnail is already present and only extract it and set it's value if it isn't
-	}
+	//Create a copy of the desktop file to edit.
+	deskCopy := new(bytes.Buffer)
+	ai.Desktop.WriteTo(deskCopy)
+	cfg, _ := ini.Load(deskCopy)
 
-	if !startingPoint {
-		cfg = ini.Empty()
-		cfg.Section("Desktop Entry").Key("Type").SetValue("Application")
+	if !cfg.Section("Desktop Entry").HasKey("Name") {
 		cfg.Section("Desktop Entry").Key("Name").SetValue(ai.Name)
-	} else {
-		if !cfg.Section("Desktop Entry").HasKey("Name") {
-			cfg.Section("Desktop Entry").Key("Name").SetValue(ai.Name)
-		}
-		if !cfg.Section("Desktop Entry").HasKey("Type") {
-			cfg.Section("Desktop Entry").Key("Type").SetValue("Application")
-		}
+	}
+	if !cfg.Section("Desktop Entry").HasKey("Type") {
+		cfg.Section("Desktop Entry").Key("Type").SetValue("Application")
 	}
 	thumbnail := ThumbnailsDirNormal + ai.md5 + ".png"
 	cfg.Section("Desktop Entry").Key("Icon").SetValue(thumbnail)
@@ -125,8 +89,28 @@ func writeDesktopFile(ai AppImage) {
 		cfg.Section("Desktop Entry").Key(helpers.UpdateInformationKey).SetValue("\"" + ui + "\"")
 	}
 	// Actions
-
-	actions := strings.Split(cfg.Section("Desktop Entry").Key("Actions").String(), "；")
+	var actions []string
+	if strings.TrimSpace(cfg.Section("Desktop Entry").Key("Actions").String()) != "" {
+		actions = strings.Split(cfg.Section("Desktop Entry").Key("Actions").String(), "；")
+		for i := 0; i < len(actions); i++ {
+			if actions[i] == "" {
+				actions = append(actions[:i], actions[i+1:]...)
+			}
+		}
+	}
+	for _, a := range actions {
+		sec := cfg.Section("Desktop Action " + a)
+		exec := sec.Key("Exec").String()
+		if exec != "" {
+			if strings.HasPrefix(exec, "\"") {
+				if strings.Contains(exec[1:], "\"") {
+					exec = exec[1 : strings.Index(exec[1:], "\"")+1]
+				}
+			}
+			spl := strings.Split(exec, " ")
+			sec.Key("Exec").SetValue(arg0abs + " wrap \"" + ai.Path + "\" " + strings.Join(spl[1:], " "))
+		}
+	}
 
 	if isWritable(ai.Path) {
 		// Add "Move to Trash" action
@@ -235,22 +219,19 @@ func writeDesktopFile(ai AppImage) {
 		cfg.Section("Desktop Action FirejailOverlayTmpfs").Key("Exec").SetValue("firejail --env=DESKTOPINTEGRATION=appimaged --noprofile --overlay-tmpfs --appimage \"" + ai.Path + "\"")
 	}
 
-	as := ""
-	for _, action := range actions {
-		as = as + action + ";"
-	}
+	as := strings.Join(actions, ";")
 	cfg.Section("Desktop Entry").Key("Actions").SetValue(as)
 
 	if *verbosePtr {
-		log.Println("desktop: Saving to", desktopcachedir+"/"+filename)
+		log.Println("desktop: Saving to", ai.desktopfilepath)
 	}
 	buf := new(bytes.Buffer)
 	cfg.WriteTo(buf)
 	out := fixDesktopFile(buf.Bytes())
-	os.Remove(desktopcachedir + "/" + filename)
-	deskFil, err := os.Create(desktopcachedir + "/" + filename)
+	os.Remove(ai.desktopfilepath)
+	deskFil, err := os.Create(ai.desktopfilepath)
 	if err != nil {
-		log.Printf("Fail to write file: %v", err)
+		log.Printf("Fail to create file: %v", err)
 		return
 	}
 	_, err = deskFil.Write(out)


### PR DESCRIPTION
- Fixes #220.
  - Additionally, if additional desktop actions are present, the Exec is replaced so it works properly.
- Fixes bugs caused by squashfs v0.6+
  - Forgot that v0.6 now does things more correctly so Open doesn't allow wildcards anymore, which broke some things.
- Added `AppImage.ListFiles` to `goappimage` to get around above.
- Changed build script so zig is not permanently installed and can be cleaned up afterwards
- Since I was already doing things with desktop files, also implemented fix I mentioned in #110.