### PR TITLE
Adjust download script to work with githubs new API

### DIFF
--- a/src/appimagetool/README.md
+++ b/src/appimagetool/README.md
@@ -7,7 +7,7 @@ This is an experimental implementation of the AppImage command line tool, `appim
 Assuming you are using a 64-bit Intel machine (amd64, also known as x86_64), you can use our pre-compiled binaries. To try it out:
 
 ```
-wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
+wget $(curl https://api.github.com/repos/probonopd/go-appimage/releases | jq -r '.[] | select(.tag_name == "continuous") | .assets[] | select((.name | endswith("x86_64.AppImage")) and (.name | contains("appimagetool"))) | .browser_download_url') -O appimagetool
 chmod +x appimagetool-*.AppImage
 ./appimagetool-*.AppImage -s deploy appdir/usr/share/applications/*.desktop # Bundle EVERYTHING
 # or 


### PR DESCRIPTION
The current wget command in the README does not work anymore. Github changed their website so the actual release info is no longer embedded into the html and is dynamically loaded.

To properly fetch the latest releasing info they recommend using their API as described here: https://docs.github.com/en/rest/releases/releases#list-releases

This changes the README to use the new API and filter with jq (since its parsing JSON).