### PR TITLE
Use predictable file names for the continuous release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,8 @@ jobs:
   build-all:
     name: Build for all architectures
     runs-on: ubuntu-18.04
+    env:
+      VERSION: continuous
     steps:
     - uses: actions/checkout@v2
     - name: Set up Go

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -206,7 +206,6 @@ done
 # Export version and build number
 if [ ! -z "$GITHUB_RUN_NUMBER" ] ; then
   export COMMIT="${GITHUB_RUN_NUMBER}"
-  export VERSION=$((GITHUB_RUN_NUMBER+646))
 else
   export COMMIT=$(date '+%Y-%m-%d_%H%M%S')
   export VERSION=$(date '+%Y-%m-%d_%H%M%S')


### PR DESCRIPTION
On each update to the continuous build the version number gets incremented. This is not ideal because it makes it impossible to predictably always download the latest continuous build.

This PR changes the version in the filename to continuous for the continuous release, so that the filenames are always the same.