### PR TITLE
Fix never-ending loop when not using kde

### DIFF
--- a/src/appimaged/udisks.go
+++ b/src/appimaged/udisks.go
@@ -127,6 +127,7 @@ retry:
 		} else {
 			log.Println("org.kde.Solid.PowerManagement might not be started yet. Waiting a moment then retrying")
 			time.Sleep(500 * time.Millisecond)
+			retried = true
 			goto retry
 		}
 	} else {


### PR DESCRIPTION
When not using KDE the journal got spammed with log messages. Seems like the exit-condition for the retry loop was not set.