### PR TITLE
Improve ld.so.conf parsing

### DIFF
--- a/src/appimagetool/appdirtool.go
+++ b/src/appimagetool/appdirtool.go
@@ -997,6 +997,9 @@ func getDirsFromSoConf(path string) []string {
 			continue
 		} else if strings.HasPrefix(line, "include ") {
 			p := strings.Split(line, " ")[1]
+			if p[0] != '/' {
+				p = filepath.Dir(path) + "/" + p
+			}
 			files, err := filepath.Glob(p)
 			if err != nil {
 				return out

--- a/src/appimagetool/appdirtool.go
+++ b/src/appimagetool/appdirtool.go
@@ -979,6 +979,10 @@ func findWithPrefixInLibraryLocations(prefix string) ([]string, error) {
 	return found, errors.New("did not find " + prefix)
 }
 
+func isBlank(c rune) bool {
+	return c == ' ' || c == '\t'
+}
+
 // getDirsFromSoConf returns a []string with the directories specified
 // in the ld config file at path, usually '/etc/ld.so.conf',
 // and in its included config files. We need to search in those locations
@@ -995,18 +999,23 @@ func getDirsFromSoConf(path string) []string {
 		line := scanner.Text()
 		if strings.TrimSpace(line) == "" || strings.HasPrefix(line, "#") {
 			continue
-		} else if strings.HasPrefix(line, "include ") {
-			p := strings.Split(line, " ")[1]
-			if p[0] != '/' {
-				p = filepath.Dir(path) + "/" + p
+		} else if strings.HasPrefix(line, "include") && isBlank(([]rune(line))[7]) {
+			incs := strings.FieldsFunc(line[8:], isBlank)
+			for _, p := range incs {
+				if p[0] != '/' {
+					p = filepath.Dir(path) + "/" + p
+				}
+				files, err := filepath.Glob(p)
+				if err != nil {
+					return out
+				}
+				for _, file := range files {
+					out = append(out, getDirsFromSoConf(file)...)
+				}
 			}
-			files, err := filepath.Glob(p)
-			if err != nil {
-				return out
-			}
-			for _, file := range files {
-				out = append(out, getDirsFromSoConf(file)...)
-			}
+			continue
+		} else if strings.HasPrefix(line, "hwcap") && isBlank(([]rune(line))[5]) {
+			// Ignore hwcap directive, it's also ignore by glibc
 			continue
 		}
 		out = append(out, strings.TrimSpace(line))


### PR DESCRIPTION
On Gentoo, ld.so.conf contains include directives using relative paths (as supported by ldconfig).
Add support for them.

The current implementation doesn't perfectly match what glibc does:
- glibc accepts every blank character after include, go-appimage only matches on space
- glibc split the remaining line by space or tab and includes all items, go-appimage only takes the first one and doesn't split on tabs,
- glibc ignores a hwcap directive, go-appimage takes it as a path.

This PR also fixes these.