### PR TITLE
fix(appimaged): avoid 'Invalid desktop file' error on Debian

### DIFF
--- a/src/appimaged/desktop.go
+++ b/src/appimaged/desktop.go
@@ -133,7 +133,7 @@ func writeDesktopFile(ai AppImage) error {
 			cfg.Section("Desktop Action Trash").Key("Exec").SetValue("kioclient move \"" + ai.Path + "\" trash:/")
 		} else {
 			// Provide a fallback shell command to prevent parser errors on other desktops
-			cfg.Section("Desktop Action Trash").Key("Exec").SetValue("mv \"" + ai.Path + "\" ~/.local/share/Trash/")
+			cfg.Section("Desktop Action Trash").Key("Exec").SetValue("mv \"" + ai.Path + "\" " + os.UserHomeDir() + "/.local/share/Trash/")
 		}
 
 		// Add OpenPortableHome action


### PR DESCRIPTION
This change should fix  #273