### PR TITLE
Fix loaders.cache patching

### DIFF
--- a/src/appimagetool/appdirtool.go
+++ b/src/appimagetool/appdirtool.go
@@ -655,14 +655,16 @@ func handleGdk(appdir helpers.AppDir) {
 						os.Exit(1)
 					}
 
-					whatToPatchAway := helpers.FilesWithSuffixInDirectoryRecursive(loc, "libpixbufloader-png.so")
-					if len(whatToPatchAway) < 1 {
-						helpers.PrintError("whatToPatchAway", errors.New("could not find directory that contains libpixbufloader-png.so"))
-						break // os.Exit(1)
+					loadersCache, err := filepath.EvalSymlinks(filepath.Dir(loadersCaches[0]))
+					if err != nil {
+						helpers.PrintError("Could not get the location of loaders.cache", err)
+						break
 					}
 
-					log.Println("Patching", appdir.Path+loadersCaches[0], "removing", filepath.Dir(whatToPatchAway[0])+"/")
-					err = PatchFile(appdir.Path+loadersCaches[0], filepath.Dir(whatToPatchAway[0])+"/", "")
+					whatToPatchAway := loadersCache + "/loaders/"
+
+					log.Println("Patching", appdir.Path+loadersCaches[0], "removing", whatToPatchAway)
+					err = PatchFile(appdir.Path+loadersCaches[0], whatToPatchAway, "")
 					if err != nil {
 						helpers.PrintError("PatchFile loaders.cache", err)
 						break // os.Exit(1)


### PR DESCRIPTION
Follow-up to comment https://github.com/probonopd/go-appimage/issues/284#issuecomment-2205119529 in PR form.

This change results in the following output when patching `loaders.cache`:

> Patching appdir/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders.cache removing /usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders/

I've verified that correctly patches `loaders.cache`, as confirmed by using it to build Inkscape (https://gitlab.com/pbs3141/inkscape/-/jobs/7264527507).

Fixes https://github.com/probonopd/go-appimage/issues/284