### PR TITLE
Make GTK input methods work

### DIFF
--- a/src/appimagetool/appdirtool.go
+++ b/src/appimagetool/appdirtool.go
@@ -209,14 +209,14 @@ func AppDirDeploy(path string) {
 	// GStreamer
 	handleGStreamer(appdir)
 
-	// Gtk 3 modules/plugins
-	// If there is a .so with the name libgtk-3 inside the AppDir, then we need to
+	// Gtk modules/plugins
+	// If there is a .so with the name libgtk-* inside the AppDir, then we need to
 	// bundle Gdk modules/plugins
+	deployGtkDirectory(appdir, 4)
 	deployGtkDirectory(appdir, 3)
-
-	// Gtk 2 modules/plugins
-	// Same as above, but for Gtk 2
 	deployGtkDirectory(appdir, 2)
+
+	deployGtkUiFiles(appdir)
 
 	// ALSA
 	handleAlsa(appdir)
@@ -817,11 +817,13 @@ func deployGtkDirectory(appdir helpers.AppDir, gtkVersion int) {
 				for _, loc := range locs {
 					log.Println("Bundling dependencies of Gtk", strconv.Itoa(gtkVersion), "directory...")
 					determineELFsInDirTree(appdir, loc)
-					log.Println("Bundling Default theme for Gtk", strconv.Itoa(gtkVersion), "(for GTK_THEME=Default)...")
-					err = copy.Copy("/usr/share/themes/Default/gtk-"+strconv.Itoa(gtkVersion)+".0", appdir.Path+"/usr/share/themes/Default/gtk-"+strconv.Itoa(gtkVersion)+".0")
-					if err != nil {
-						helpers.PrintError("Copy", err)
-						os.Exit(1)
+					if gtkVersion <= 3 {
+						log.Println("Bundling Default theme for Gtk", strconv.Itoa(gtkVersion), "(for GTK_THEME=Default)...")
+						err = copy.Copy("/usr/share/themes/Default/gtk-"+strconv.Itoa(gtkVersion)+".0", appdir.Path+"/usr/share/themes/Default/gtk-"+strconv.Itoa(gtkVersion)+".0")
+						if err != nil {
+							helpers.PrintError("Copy", err)
+							os.Exit(1)
+						}
 					}
 
 					/*
@@ -837,7 +839,9 @@ func deployGtkDirectory(appdir helpers.AppDir, gtkVersion int) {
 			break
 		}
 	}
+}
 
+func deployGtkUiFiles(appdir helpers.AppDir) {
 	// Check for the presence of Gtk .ui files
 	uifiles := helpers.FilesWithSuffixInDirectoryRecursive(appdir.Path, ".ui")
 	if len(uifiles) > 0 {

--- a/src/appimagetool/appdirtool.go
+++ b/src/appimagetool/appdirtool.go
@@ -128,16 +128,14 @@ LD_LINUX=$(find "$HERE" -name 'ld-*.so.*' | head -n 1)
 if [ -e "$LD_LINUX" ] ; then
   export GCONV_PATH="$HERE/usr/lib/gconv"
   export FONTCONFIG_FILE="$HERE/etc/fonts/fonts.conf"
-  export GTK_EXE_PREFIX="$HERE/usr"
+  export GTK_PATH=$(find "$HERE/lib" -name gtk-* -type d)
   export GTK_THEME=Default # This one should be bundled so that it can work on systems without Gtk
   export GDK_PIXBUF_MODULEDIR=$(find "$HERE" -name loaders -type d -path '*gdk-pixbuf*')
   export GDK_PIXBUF_MODULE_FILE=$(find "$HERE" -name loaders.cache -type f -path '*gdk-pixbuf*') # Patched to contain no paths
-  # export LIBRARY_PATH=$GDK_PIXBUF_MODULEDIR # Otherwise getting "Unable to load image-loading module"
   export XDG_DATA_DIRS="${HERE}"/usr/share/:"${XDG_DATA_DIRS}"
   export PERLLIB="${HERE}"/usr/share/perl5/:"${HERE}"/usr/lib/perl5/:"${PERLLIB}"
   export GSETTINGS_SCHEMA_DIR="${HERE}"/usr/share/glib-2.0/runtime-schemas/:"${HERE}"/usr/share/glib-2.0/schemas/:"${GSETTINGS_SCHEMA_DIR}"
   export QT_PLUGIN_PATH="$(readlink -f "$(dirname "$(find "${HERE}" -type d -path '*/plugins/platforms' 2>/dev/null)" 2>/dev/null)" 2>/dev/null)"
-  # exec "${LD_LINUX}" --inhibit-cache --library-path "${LIBRARY_PATH}" "${MAIN_BIN}" "$@"
   case $line in
     "ld-linux"*) exec "${LD_LINUX}" --inhibit-cache "${MAIN_BIN}" "$@" ;;
     *) exec "${LD_LINUX}" "${MAIN_BIN}" "$@" ;;


### PR DESCRIPTION
This attempts to get input methods working for packaged apps using GTK3 and GTK4.

First of all, `appdirtool.go` didn't even handle GTK4 (it was hard-coded to 2 and 3), so GTK's loadable modules weren't even being deployed. The first commit fixes this by adding support for version 4. This resulted in an error in the step "Bundling Default theme for Gtk", since there is no default theme for GTK4, so this step was restricted to versions <= 3. Along the way I noticed "Gtk .ui files found." was running multiple times (once for each GTK version), so this was fixed too.

The above still didn't get input methods working in GTK4 apps, since GTK was looking in the wrong place for its loadable modules, as checked with `GTK_DEBUG=modules`. This was related to the `GTK_EXE_PREFIX` variable being set wrong. I couldn't find any value of this variable that would work, so I deleted it and set `GTK_PATH` instead (third commit).

GTK3 also requires `immodules.cache` to be bundled and patched (unlike GTK4, which has no such file). So code was added to do this on versions <= 3 (second commit).

I have tested the above changes with Inkscape (GTK4) and confirmed that it works. Although I have tested the GTK3-specific code too, I haven't tested it with a real GTK3 app (GIMP), so could do with some help with that (@brunvonlope).

This PR is supposed to fix https://github.com/probonopd/go-appimage/issues/282. In that issue, there were two suggestions: bundle and patch `immodules.cache`, and set `GTK_IM_MODULE_FILE`. The first suggestion is done here, while the second is not since `GTK_IM_MODULE_FILE` no longer exists in GTK4 ([doc](https://docs.gtk.org/gtk4/running.html)), and we want a solution that works for all GTK versions if possible. It might be that it does need to be set though, in which case doing it for GTK <= 3 would be harmless, since it is ignored by GTK4.