### PR TITLE
Recover from panic during integration

### DIFF
--- a/src/appimaged/integration.go
+++ b/src/appimaged/integration.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -20,6 +21,13 @@ var integrationLock sync.Mutex
 
 func AddIntegration(path string, notify bool) (err error) {
 	integrationLock.Lock()
+	defer func() {
+		if err := recover(); err != nil {
+			l := log.New(os.Stderr, "", 1)
+			l.Println("ERROR panic caught while integrating "+path+": ", err)
+			sendDesktopNotification("Critical Error", "See log for details. Please create an issue on Github, providing appimaged's logs.", 5000)
+		}
+	}()
 	defer integrationLock.Unlock()
 	if _, ok := integrations[path]; ok {
 		return


### PR DESCRIPTION
I relatively recently learned about Go's `recover` ability. Now a panic when integrating AppImages will fail nicely instead of crashing `appimaged` entirely. I added a desktop notification when this happens to alert the user and asking them to create a GitHub issue.