### PR TITLE
Dwarfs AppImage support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,49 +3,50 @@ name: Build All Architectures
 on:
   workflow_dispatch:
   push:
-    branches:    
-      - 'master'
+    branches:
+      - "master"
     paths-ignore:
-      - '.idea/..'
-      - 'docs/**'
+      - ".idea/.."
+      - "docs/**"
   pull_request:
     paths-ignore:
-      - '.idea/..'
-      - 'docs/**'
+      - ".idea/.."
+      - "docs/**"
 
 jobs:
   build-all:
     name: Build for all architectures
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '>=1.23'
-    - uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Run build script
-      run: ./scripts/build.sh -a amd64,386,arm64,arm
-    - name: Upload to GitHub Artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: artifacts
-        path: ./build/*
-    - name: Upload to GitHub Releases
-      if: github.event_name != 'pull_request' && github.ref_name == 'master'
-      uses: "marvinpinto/action-automatic-releases@latest"
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "continuous"
-        prerelease: true
-        title: "Continuous Build"
-        files: |
-          ./build/*
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ">=1.23"
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run build script
+        run: ./scripts/build.sh -a amd64,386,arm64,arm
+      - name: Upload to GitHub Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts
+          path: ./build/*
+      - name: Upload to GitHub Releases
+        if: github.event_name != 'pull_request' && github.ref_name == 'master'
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "continuous"
+          prerelease: true
+          title: "Continuous Build"
+          files: |
+            ./build/*
+
 #

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -10,23 +10,23 @@ on:
 jobs:
   artifacts-url-comments:
     name: Add artifact links to PR and issues
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # Restrict permissions for the GITHUB_TOKEN, https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     permissions:
       issues: write
       pull-requests: write
       actions: read
-      
+
     steps:
-    - name: Add artifact links to PR and issues
-      if: github.event.workflow_run.event == 'pull_request'
-      uses: tonyhallett/artifacts-url-comments@0965ff1a7ae03c5c1644d3c30f956effea4e05ef # v1.1.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        prefix: "Build for testing:"
-        suffix: "Use at your own risk."
-        format: name
-        addTo: pull
-        errorNoArtifacts: false
+      - name: Add artifact links to PR and issues
+        if: github.event.workflow_run.event == 'pull_request'
+        uses: tonyhallett/artifacts-url-comments@0965ff1a7ae03c5c1644d3c30f956effea4e05ef # v1.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          prefix: "Build for testing:"
+          suffix: "Use at your own risk."
+          format: name
+          addTo: pull
+          errorNoArtifacts: false

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/probonopd/go-appimage
 
-go 1.23
+go 1.24.0
+
+toolchain go1.24.2
 
 require (
-	github.com/CalebQ42/squashfs v1.0.4
+	github.com/CalebQ42/squashfs v1.2.0
 	github.com/acobaugh/osrelease v0.1.0
 	github.com/adrg/xdg v0.5.0
 	github.com/alokmenghrajani/gpgeez v0.0.0-20161206084504-1a06f1c582f9
@@ -42,9 +44,9 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
-	github.com/klauspost/compress v1.17.9 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/pierrec/lz4/v4 v4.1.21 // indirect
+	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/rasky/go-lzo v0.0.0-20200203143853-96a758eda86e // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/rustyoz/Mtransform v0.0.0-20190224104252-60c8c35a3681 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/CalebQ42/squashfs v1.0.4 h1:v7d6BxamgumtvqkOmezEOHmlBUGP4+Epewoin0JZ6LA=
-github.com/CalebQ42/squashfs v1.0.4/go.mod h1:uhKIQfq2+dgJ+utqCkvVk0t7XuqaNhcotCrqSI0wUuI=
+github.com/CalebQ42/squashfs v1.2.0 h1:FjkSNQgHPM8pygHoZASjAwwy502B12MO9yCh+fZgA1k=
+github.com/CalebQ42/squashfs v1.2.0/go.mod h1:48nUwPN4mjeWhu3It2LJZAq4EkixbzY4pdyZ7gEfHb8=
 github.com/acobaugh/osrelease v0.1.0 h1:Yb59HQDGGNhCj4suHaFQQfBps5wyoKLSSX/J/+UifRE=
 github.com/acobaugh/osrelease v0.1.0/go.mod h1:4bFEs0MtgHNHBrmHCt67gNisnabCRAlzdVasCEGHTWY=
 github.com/adrg/xdg v0.5.0 h1:dDaZvhMXatArP1NPHhnfaQUqWBLBsmx1h1HXQdMoFCY=
@@ -59,8 +59,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
-github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
-github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -78,8 +78,8 @@ github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc
 github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
 github.com/otiai10/mint v1.5.1/go.mod h1:MJm72SBthJjz8qhefc4z1PYEieWmy8Bku7CjcAqyUSM=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
-github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
-github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
+github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -106,6 +106,7 @@ build () {
   cp $PROJECT/data/appimage.png $BUILDDIR/$PROG-$ARCH.AppDir/
   if [ $PROG == appimaged ]; then
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/bsdtar-$AIARCH -O bsdtar )
+    ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/mhx/dwarfs/releases/download/v0.12.3/dwarfs-fuse-extract-0.12.3-Linux-$AIARCH -O dwarfs )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/unsquashfs-$AIARCH -O unsquashfs )
     cat > $BUILDDIR/$PROG-$ARCH.AppDir/appimaged.desktop <<\EOF
 [Desktop Entry]
@@ -126,7 +127,7 @@ EOF
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/runtime-fuse3-aarch64 -O runtime-aarch64 )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/runtime-fuse3-armhf -O runtime-armhf )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/runtime-fuse3-i686 -O runtime-i686 )
-    ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/runtime-fuse3-x86_64 -O runtime-x86_64 )     
+    ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/runtime-fuse3-x86_64 -O runtime-x86_64 )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh -O uploadtool )
     cat > $BUILDDIR/$PROG-$ARCH.AppDir/appimagetool.desktop <<\EOF
 [Desktop Entry]
@@ -146,7 +147,7 @@ EOF
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/runtime-fuse3-aarch64 -O runtime-aarch64 )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/runtime-fuse3-armhf -O runtime-armhf )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/runtime-fuse3-i686 -O runtime-i686 )
-    ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/runtime-fuse3-x86_64 -O runtime-x86_64 )    
+    ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/runtime-fuse3-x86_64 -O runtime-x86_64 )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh -O uploadtool )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/bsdtar-$AIARCH -O bsdtar )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/unsquashfs-$AIARCH -O unsquashfs )

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -109,8 +109,8 @@ build () {
     # dwarfs only compiles for arm64 and amd64
     if [ $ARCH == arm64 ] || [ $ARCH == amd64 ]; then
     	( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/mhx/dwarfs/releases/download/v0.12.3/dwarfs-fuse-extract-0.12.3-Linux-$AIARCH -O dwarfs )
+    	( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; ln -sf dwarfs dwarfsextract )
     fi
-    ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; ln -sf dwarfs dwarfsextract )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/unsquashfs-$AIARCH -O unsquashfs )
     cat > $BUILDDIR/$PROG-$ARCH.AppDir/appimaged.desktop <<\EOF
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -106,7 +106,10 @@ build () {
   cp $PROJECT/data/appimage.png $BUILDDIR/$PROG-$ARCH.AppDir/
   if [ $PROG == appimaged ]; then
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/bsdtar-$AIARCH -O bsdtar )
-    ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/mhx/dwarfs/releases/download/v0.12.3/dwarfs-fuse-extract-0.12.3-Linux-$AIARCH -O dwarfs )
+    # dwarfs only compiles for arm64 and amd64
+    if [ $ARCH == arm64 ] || [ $ARCH == amd64 ]; then
+    	( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/mhx/dwarfs/releases/download/v0.12.3/dwarfs-fuse-extract-0.12.3-Linux-$AIARCH -O dwarfs )
+    fi
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; ln -sf dwarfs dwarfsextract )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/unsquashfs-$AIARCH -O unsquashfs )
     cat > $BUILDDIR/$PROG-$ARCH.AppDir/appimaged.desktop <<\EOF

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -107,8 +107,10 @@ build () {
   if [ $PROG == appimaged ]; then
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/bsdtar-$AIARCH -O bsdtar )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/mhx/dwarfs/releases/download/v0.12.3/dwarfs-fuse-extract-0.12.3-Linux-$AIARCH -O dwarfs )
+    ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; ln -sf dwarfs dwarfsextract )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/unsquashfs-$AIARCH -O unsquashfs )
     cat > $BUILDDIR/$PROG-$ARCH.AppDir/appimaged.desktop <<\EOF
+
 [Desktop Entry]
 Type=Application
 Name=appimaged

--- a/src/appimaged/appimaged.go
+++ b/src/appimaged/appimaged.go
@@ -102,7 +102,7 @@ func main() {
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "\n")
-		fmt.Fprintf(os.Stderr, filepath.Base(os.Args[0])+" "+version+"\n")
+		fmt.Fprintf(os.Stderr, "%s", filepath.Base(os.Args[0])+" "+version+"\n")
 		fmt.Fprintf(os.Stderr, "\n")
 		fmt.Fprintf(os.Stderr, "Optional daemon that registers AppImages and integrates them with the system.\n")
 		fmt.Fprintf(os.Stderr, "\n")

--- a/src/appimaged/thumbnail.go
+++ b/src/appimaged/thumbnail.go
@@ -40,6 +40,7 @@ func (ai AppImage) getThumbnailOrIcon() (out []byte) {
 		fmt.Println("Error getting thumbnail")
 		goto icon
 	}
+	defer rdr.Close()
 	out, err = io.ReadAll(rdr)
 	if err != nil {
 		fmt.Println("Error reading thumbnail")
@@ -58,6 +59,7 @@ icon:
 		fmt.Println("Error getting icon")
 		return fallback
 	}
+	defer rdr.Close()
 	out, err = io.ReadAll(rdr)
 	if err != nil {
 		fmt.Println("Error reading icon")

--- a/src/goappimage/type2dwarfsreader.go
+++ b/src/goappimage/type2dwarfsreader.go
@@ -1,56 +1,172 @@
 package goappimage
 
 import (
+	"errors"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 )
 
 type type2DwarfsReader struct {
-	mountPoint string
-	unmount    *time.Timer
+	mountPoint  string
+	aiPath      string
+	fileReadNum int
+	unmount     *time.Timer
 }
 
-func newType2DwarfsReader(ai AppImage) (*type2DwarfsReader, error) {
+func newType2DwarfsReader(ai *AppImage) (*type2DwarfsReader, error) {
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "appimaged-")
 	if err != nil {
 		return nil, err
 	}
-	cmd := exec.Command("dwarfs", ai.Path, tmpDir, "-o offset=auto")
+	cmd := exec.Command("dwarfs", ai.Path, tmpDir, "-o", "offset=auto")
 	err = cmd.Run()
 	if err != nil {
-		exec.Command("umount", tmpDir)
+		exec.Command("umount", tmpDir).Run()
 		return nil, err
 	}
 	out := &type2DwarfsReader{
 		mountPoint: tmpDir,
+		aiPath:     ai.Path,
 	}
 	out.unmount = time.AfterFunc(5*time.Second, func() {
-		exec.Command("umount", tmpDir)
+		exec.Command("umount", tmpDir).Run()
+		os.RemoveAll(tmpDir)
 		out.mountPoint = ""
 	})
 	return out, nil
 }
 
-func (r *type2DwarfsReader) mountOrPauseUnmount() {
+func (r *type2DwarfsReader) mountOrPauseUnmount() error {
 	if r.mountPoint != "" {
 		r.unmount.Stop()
-		return
+		return nil
 	}
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "appimaged-")
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("dwarfs", r.aiPath, tmpDir, "-o", "offset=auto")
+	err = cmd.Run()
+	if err != nil {
+		exec.Command("umount", tmpDir).Run()
+		return err
+	}
+	return nil
 }
 
 func (r *type2DwarfsReader) resumeTimer() {
-	r.unmount = time.AfterFunc(5*time.Second, func() {
-		exec.Command("umount", r.mountPoint)
-		r.mountPoint = ""
-	})
+	if r.fileReadNum == 0 {
+		r.unmount = time.AfterFunc(5*time.Second, func() {
+			exec.Command("umount", r.mountPoint).Run()
+			os.RemoveAll(r.mountPoint)
+			r.mountPoint = ""
+		})
+	}
 }
 
-func (r *type2DwarfsReader) FileReader(path string) (io.ReadCloser, error)
+type type2DwarfsFile struct {
+	fil *os.File
+	rdr *type2DwarfsReader
+}
 
-func (r *type2DwarfsReader) IsDir(path string) bool
+func (f type2DwarfsFile) Read(b []byte) (int, error) {
+	return f.fil.Read(b)
+}
 
-func (r *type2DwarfsReader) ListFiles(path string) []string
+func (f type2DwarfsFile) Close() error {
+	f.fil.Close()
+	f.rdr.fileReadNum--
+	if f.rdr.fileReadNum == 0 {
+		f.rdr.resumeTimer()
+	}
+	return nil
+}
 
-func (r *type2DwarfsReader) ExtractTo(path, destination string, resolveSymlinks bool) error
+func (r *type2DwarfsReader) FileReader(path string) (io.ReadCloser, error) {
+	err := r.mountOrPauseUnmount()
+	if err != nil {
+		return nil, err
+	}
+	fil, err := os.Open(filepath.Join(r.mountPoint, path))
+	if err != nil {
+		r.resumeTimer()
+		return nil, err
+	}
+	if stat, _ := fil.Stat(); stat.Mode()&os.ModeSymlink == os.ModeSymlink {
+		var link string
+		link, err = os.Readlink(filepath.Join(r.mountPoint, path))
+		if err != nil {
+			return nil, errors.New("Can't resolve symlink at: " + path)
+		}
+		fil, err = os.Open(filepath.Join(r.mountPoint, path, link))
+		if err != nil {
+			return nil, errors.New("Can't resolve symlink at: " + path)
+		}
+	}
+	if stat, _ := fil.Stat(); !stat.Mode().IsRegular() {
+		return nil, errors.New("Path is a directory: " + path)
+	}
+	r.fileReadNum++
+	return type2DwarfsFile{
+		fil: fil,
+		rdr: r,
+	}, nil
+}
+
+func (r *type2DwarfsReader) IsDir(path string) bool {
+	err := r.mountOrPauseUnmount()
+	if err != nil {
+		return false
+	}
+	defer r.resumeTimer()
+	stat, err := os.Stat(filepath.Join(r.mountPoint, path))
+	if err != nil {
+		return false
+	}
+	return stat.IsDir()
+}
+
+func (r *type2DwarfsReader) ListFiles(path string) []string {
+	err := r.mountOrPauseUnmount()
+	if err != nil {
+		return nil
+	}
+	defer r.resumeTimer()
+	fil, err := os.Open(filepath.Join(r.mountPoint, path))
+	if err != nil {
+		return nil
+	}
+	names, _ := fil.Readdirnames(-1)
+	return names
+}
+
+func (r *type2DwarfsReader) ExtractTo(path, destination string, resolveSymlinks bool) error {
+	if resolveSymlinks {
+		err := r.mountOrPauseUnmount()
+		if err != nil {
+			return nil
+		}
+		defer r.resumeTimer()
+		stat, err := os.Stat(filepath.Join(r.mountPoint, path))
+		if err != nil {
+			return err
+		}
+		if stat.Mode()&os.ModeSymlink == os.ModeSymlink {
+			var symPath string
+			symPath, err = os.Readlink(filepath.Join(r.mountPoint, path))
+			if err != nil {
+				return err
+			}
+			path = filepath.Join(path, symPath)
+		}
+	}
+	cmd := exec.Command("dwarfsextract",
+		"-i", r.aiPath,
+		"--pattern=\""+path+"\"",
+		"-O", "auto",
+		"-o", destination)
+	return cmd.Run()
+}

--- a/src/goappimage/type2dwarfsreader.go
+++ b/src/goappimage/type2dwarfsreader.go
@@ -17,6 +17,14 @@ type type2DwarfsReader struct {
 }
 
 func newType2DwarfsReader(ai *AppImage) (*type2DwarfsReader, error) {
+	pth, _ := exec.LookPath("dwarfs")
+	if pth == "" {
+		return nil, errors.New("dwarfs not found in PATH, cannot read dwarfs AppImage")
+	}
+	pth, _ = exec.LookPath("dwarfsextract")
+	if pth == "" {
+		return nil, errors.New("dwarfsextract not found in PATH, cannot read dwarfs AppImage")
+	}
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "appimaged-")
 	if err != nil {
 		return nil, err

--- a/src/goappimage/type2dwarfsreader.go
+++ b/src/goappimage/type2dwarfsreader.go
@@ -1,0 +1,56 @@
+package goappimage
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+type type2DwarfsReader struct {
+	mountPoint string
+	unmount    *time.Timer
+}
+
+func newType2DwarfsReader(ai AppImage) (*type2DwarfsReader, error) {
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "appimaged-")
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command("dwarfs", ai.Path, tmpDir, "-o offset=auto")
+	err = cmd.Run()
+	if err != nil {
+		exec.Command("umount", tmpDir)
+		return nil, err
+	}
+	out := &type2DwarfsReader{
+		mountPoint: tmpDir,
+	}
+	out.unmount = time.AfterFunc(5*time.Second, func() {
+		exec.Command("umount", tmpDir)
+		out.mountPoint = ""
+	})
+	return out, nil
+}
+
+func (r *type2DwarfsReader) mountOrPauseUnmount() {
+	if r.mountPoint != "" {
+		r.unmount.Stop()
+		return
+	}
+}
+
+func (r *type2DwarfsReader) resumeTimer() {
+	r.unmount = time.AfterFunc(5*time.Second, func() {
+		exec.Command("umount", r.mountPoint)
+		r.mountPoint = ""
+	})
+}
+
+func (r *type2DwarfsReader) FileReader(path string) (io.ReadCloser, error)
+
+func (r *type2DwarfsReader) IsDir(path string) bool
+
+func (r *type2DwarfsReader) ListFiles(path string) []string
+
+func (r *type2DwarfsReader) ExtractTo(path, destination string, resolveSymlinks bool) error

--- a/src/goappimage/type2squashfsreader.go
+++ b/src/goappimage/type2squashfsreader.go
@@ -1,0 +1,109 @@
+package goappimage
+
+import (
+	"errors"
+	"io"
+	"os"
+
+	"github.com/CalebQ42/squashfs"
+)
+
+type type2SquashfsReader struct {
+	rdr *squashfs.Reader
+}
+
+func newType2SquashfsReader(ai *AppImage) (*type2SquashfsReader, error) {
+	aiFil, err := os.Open(ai.Path)
+	if err != nil {
+		return nil, err
+	}
+	squashRdr, err := squashfs.NewReaderAtOffset(aiFil, ai.offset)
+	if err != nil {
+		return nil, err
+	}
+	return &type2SquashfsReader{
+		rdr: squashRdr,
+	}, nil
+}
+
+// type anonymousCloser struct {
+// 	close func() error
+// }
+
+// func (a anonymousCloser) Close() error {
+// 	return a.close()
+// }
+
+func (r *type2SquashfsReader) FileReader(filepath string) (io.ReadCloser, error) {
+	//TODO: command fallback
+	fsFil, err := r.rdr.Open(filepath)
+	if err != nil {
+		return nil, err
+	}
+	fil := fsFil.(*squashfs.File)
+	for fil.IsSymlink() {
+		symFil := fil.GetSymlinkFile()
+		if symFil == nil {
+			return nil, errors.New("Can't resolve symlink at: " + filepath)
+		}
+		fil = symFil.(*squashfs.File)
+	}
+	if fil.IsDir() {
+		return nil, errors.New("Path is a directory: " + filepath)
+	}
+	return fil, nil
+}
+
+func (r *type2SquashfsReader) IsDir(filepath string) bool {
+	fsFil, err := r.rdr.Open(filepath)
+	if err != nil {
+		return false
+	}
+	fil := fsFil.(*squashfs.File)
+	for fil.IsSymlink() {
+		symFil := fil.GetSymlinkFile()
+		if symFil == nil {
+			return false
+		}
+		fil = symFil.(*squashfs.File)
+	}
+	return fil.IsDir()
+}
+
+func (r *type2SquashfsReader) ListFiles(path string) []string {
+	fsFil, err := r.rdr.Open(path)
+	if err != nil {
+		return nil
+	}
+	fil := fsFil.(*squashfs.File)
+	for fil.IsSymlink() {
+		symFil := fil.GetSymlinkFile()
+		if symFil == nil {
+			return nil
+		}
+		fil = symFil.(*squashfs.File)
+	}
+	if !fil.IsDir() {
+		return nil
+	}
+	children, err := fil.ReadDir(0)
+	if err != nil {
+		return nil
+	}
+	out := make([]string, len(children))
+	for _, child := range children {
+		out = append(out, child.Name())
+	}
+	return out
+}
+
+func (r *type2SquashfsReader) ExtractTo(filepath, destination string, resolveSymlinks bool) error {
+	fsFil, err := r.rdr.Open(filepath)
+	if err != nil {
+		return err
+	}
+	options := squashfs.DefaultOptions()
+	options.DereferenceSymlink = true
+	err = fsFil.(*squashfs.File).ExtractWithOptions(destination, options)
+	return err
+}

--- a/src/goappimage/type2squashfsreader.go
+++ b/src/goappimage/type2squashfsreader.go
@@ -22,7 +22,7 @@ func newType2SquashfsReader(ai *AppImage) (*type2SquashfsReader, error) {
 		return nil, err
 	}
 	return &type2SquashfsReader{
-		rdr: squashRdr,
+		rdr: &squashRdr,
 	}, nil
 }
 
@@ -103,7 +103,7 @@ func (r *type2SquashfsReader) ExtractTo(filepath, destination string, resolveSym
 		return err
 	}
 	options := squashfs.DefaultOptions()
-	options.DereferenceSymlink = true
+	options.DereferenceSymlink = resolveSymlinks
 	err = fsFil.(*squashfs.File).ExtractWithOptions(destination, options)
 	return err
 }


### PR DESCRIPTION
* Added dwarfs implementation to goappimage using the `dwarfs` and `dwarfsextract` commands.
  * Fuse mounts to /tmp for most uses, with it automatically unmounting after 5 seconds of inactivity
* Added `dwarfs` (and symlink for `dwarfsextract`) executable to appimaged.on amd64 & arch64 (there are no 32 bit executables)
* Updated github actions to ubuntu-24.04 due to 20.04 being depreciated.