### PR TITLE
use the system ssl certs

### DIFF
--- a/src/appimagetool/appdirtool.go
+++ b/src/appimagetool/appdirtool.go
@@ -67,6 +67,23 @@ if [ -e "${HERE}"/usr/share/tcltk/tcl8.6 ] ; then
 fi
 
 ############################################################################################
+# Use the system OpenSSL certificates if available
+############################################################################################
+
+# On most modern machines
+if [ -e /etc/ssl/certs/ca-certificates.crt ]; then
+  export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+# Legacy versions of RHEL/Fedora
+elif [ -e /etc/ssl/certs/ca-bundle.crt ]; then
+  export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+# Misc
+elif [ -e /etc/ssl/cacert.pem ]; then
+  export SSL_CERT_FILE=/etc/ssl/cacert.pem
+elif [ -e /etc/ssl/cert.pem ]; then
+  export SSL_CERT_FILE=/etc/ssl/cert.pem
+fi
+
+############################################################################################
 # Make it look more native on Gtk+ based systems
 ############################################################################################
 


### PR DESCRIPTION
Closes #28

Opted to use the system certificates as it's a fair bit easier, and having apps with expired or potentially compromised certs Isn't Great - plus bundled certs can always be added later! I believe these are the most common locations for the certs as well, with most distros having one or [multiple](https://gitlab.archlinux.org/archlinux/packaging/packages/ca-certificates/-/blob/36e4e3b75a052b7d37677792a02833824d2bc501/PKGBUILD#L74-82)

Tested this change with an AppImage for [Prism Launcher](https://prismlauncher.org)
