### PR TITLE
deploy qt `tls` plugins

### DIFF
--- a/src/appimagetool/appdirtool.go
+++ b/src/appimagetool/appdirtool.go
@@ -1356,6 +1356,18 @@ func handleQt(appdir helpers.AppDir, qtVersion int) {
 		for _, lib := range allELFs {
 			if strings.HasSuffix(lib, fmt.Sprintf("libQt%dNetwork.so.%d", qtVersion, qtVersion)) == true {
 				determineELFsInDirTree(appdir, qtPrfxpath+"/plugins/bearer/")
+				determineELFsInDirTree(appdir, qtPrfxpath+"/plugins/tls/")
+
+				// TLS plugins in Qt 6 require OpenSSL 3
+				if qtVersion >= 6 {
+					sslLibrary, err := findLibrary("libssl.so.3")
+					if err != nil {
+						helpers.PrintError("Could not find libssl.so.3", err)
+						os.Exit(1)
+					}
+					determineELFsInDirTree(appdir, sslLibrary)
+				}
+
 				break
 			}
 		}


### PR DESCRIPTION
The `tls` plugins (which I think are just renamed from `bearer` in newer versions of Qt...?) are usually required with Qt Network. Goes well with #359 in getting more Qt app bundles working OOTB
