### PR TITLE
docs: appimagetool: document env var for Qt install root

### DIFF
--- a/src/appimagetool/README.md
+++ b/src/appimagetool/README.md
@@ -18,6 +18,10 @@ VERSION=1.0 ./appimagetool-*.AppImage ./AppDir # turn AppDir into AppImage
 
 <https://github.com/probonopd/go-appimage/releases/tag/continuous> has builds for 32-bit Intel, 32-bit ARM (e.g., Raspberry Pi), and 64-bit ARM.
 
+### Recognized env vars
+
+- `QTDIR`: root directory for the Qt installation to copy shared libraries from, e.g. `/usr/lib/qt6/`
+
 ## Features
 
 Implemented


### PR DESCRIPTION
Hey,

I had to go through the code to find this information, so it's definitely useful to have in the docs

Thanks!

Adel