### PR TITLE
Add --preserve_cwd option to disable cds in AppRun

### DIFF
--- a/src/appimagetool/cli.go
+++ b/src/appimagetool/cli.go
@@ -32,6 +32,7 @@ func bootstrapAppImageDeploy(c *cli.Context) error {
 	options = DeployOptions{
 		standalone:     c.Bool("standalone"),
 		libAppRunHooks: c.Bool("libapprun_hooks"),
+		preserveCwd:    c.Bool("preserve_cwd"),
 	}
 	AppDirDeploy(c.Args().Get(0))
 	return nil
@@ -277,6 +278,10 @@ func main() {
 			Name:    "standalone",
 			Aliases: []string{"s"},
 			Usage:   "Make standalone self-contained bundle",
+		},
+		&cli.BoolFlag{
+			Name:    "preserve_cwd",
+			Usage:   "Preserve the current working directory when running the app",
 		},
 	}
 


### PR DESCRIPTION
Fixes issue https://github.com/probonopd/go-appimage/issues/147, and this error in the Inkscape AppImage making it unable to open relative paths:

```
$ ./Inkscape.AppImage myfile.svg
Can't open file: /tmp/.mount_InkscaanEjEO/myfile.svg (doesn't exist)
```