### PR TITLE
src: Do not throw error if alsa-lib is not present

### DIFF
--- a/src/appimagetool/appdirtool.go
+++ b/src/appimagetool/appdirtool.go
@@ -754,7 +754,6 @@ func handleAlsa(appdir helpers.AppDir) {
 			if err != nil {
 				log.Println("Could not find alsa-lib directory")
 				log.Println("E.g., in Alpine Linux: apk add alsa-plugins alsa-plugins-pulse")
-				os.Exit(1)
 			} else {
 				log.Println("Bundling dependencies of alsa-lib directory...")
 				determineELFsInDirTree(appdir, locs[0])


### PR DESCRIPTION
I am trying to ~~build~~ bundle `libasound*.so` to fix https://gitlab.gnome.org/GNOME/gimp/-/issues/13602 but go-appimage is failing due to alsa-lib-plugins package not being installed.

Then, I installed it to test. However, on my tests, deleting alsa-lib and pulseaudio dirs have no impact on GIMP MIDI functionality. In other words, packagers should be able to just bundle libasound*.so according to its minimum needs. Exiting the tool with an error is incorrect.