### PR TITLE
`mkappimage`: bundle `appstreamcli`

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -140,6 +140,7 @@ Terminal=true
 NoDisplay=true
 EOF
   elif [ $PROG == mkappimage ]; then
+    ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/appstreamcli-$AIARCH -O appstreamcli )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/desktop-file-validate-$AIARCH -O desktop-file-validate )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/mksquashfs-$AIARCH -O mksquashfs )
     ( cd $BUILDDIR/$PROG-$ARCH.AppDir/usr/bin/ ; wget -c https://github.com/probonopd/static-tools/releases/download/continuous/patchelf-$AIARCH -O patchelf )


### PR DESCRIPTION
Similar to `appimagetool`, `mkappimage` will attempt to verify AppStream
information. This can break when the tool isn't present, so we should be
bundling it here as well
