### PR TITLE
fix/improve programs reported version + add persistent releases support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,13 @@ jobs:
     name: Build for all architectures
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
+      with:
+        clean: false
+        fetch-depth: 0
+        fetch-tags: true
+        filter: tree:0
+        show-progress: false
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
@@ -31,6 +37,13 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Setup build
+      run: >
+        printf '%s\n'
+        COMMIT="$GITHUB_SHA"
+        PROJECT="$GITHUB_WORKSPACE"
+        VERSION="$((GITHUB_RUN_NUMBER+646))"
+        | tee "$GITHUB_ENV"
     - name: Run build script
       run: ./scripts/build.sh -a amd64,386,arm64,arm
     - name: Upload to GitHub Artifacts
@@ -40,12 +53,7 @@ jobs:
         path: ./build/*
     - name: Upload to GitHub Releases
       if: github.event_name != 'pull_request' && github.ref_name == 'master'
-      uses: "marvinpinto/action-automatic-releases@latest"
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "continuous"
-        prerelease: true
-        title: "Continuous Build"
-        files: |
-          ./build/*
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: ./scripts/release.sh continuous "$COMMIT" ./build/*
 #

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,12 +18,18 @@ jobs:
     name: Build for all architectures
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
+      with:
+        clean: false
+        fetch-depth: 0
+        fetch-tags: true
+        filter: tree:0
+        show-progress: false
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: '>=1.23'
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: |
           ~/.cache/go-build
@@ -31,21 +37,23 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Setup build
+      run: >
+        printf '%s\n'
+        COMMIT="$GITHUB_SHA"
+        PROJECT="$GITHUB_WORKSPACE"
+        VERSION="$((GITHUB_RUN_NUMBER+646))"
+        | tee "$GITHUB_ENV"
     - name: Run build script
       run: ./scripts/build.sh -a amd64,386,arm64,arm
     - name: Upload to GitHub Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: artifacts
         path: ./build/*
     - name: Upload to GitHub Releases
       if: github.event_name != 'pull_request' && github.ref_name == 'master'
-      uses: "marvinpinto/action-automatic-releases@latest"
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "continuous"
-        prerelease: true
-        title: "Continuous Build"
-        files: |
-          ./build/*
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: ./scripts/release.sh continuous "$COMMIT" ./build/*
 #

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Create Persistent Release
+
+on: workflow_dispatch
+
+jobs:
+  release:
+    name: Create persistent release
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        clean: false
+        fetch-depth: 0
+        fetch-tags: true
+        filter: tree:0
+        show-progress: false
+    - name: Setup environment
+      run: >
+        gh release view continuous --json assets,targetCommitish --jq '
+        "COMMIT=" + .targetCommitish,
+        "VERSION=" + ([.assets[].name | match("-([0-9]+)-x86_64\\.AppImage")] | first.captures[0].string // halt_error )
+        ' | tee "$GITHUB_ENV"
+    - name: Retrieve assets
+      run: gh release download --dir build continuous
+    - name: Publish release
+      run: ./scripts/release.sh "$VERSION" "$COMMIT" ./build/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Create Persistent Release
+
+on: workflow_dispatch
+
+jobs:
+  release:
+    name: Create persistent release
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        clean: false
+        fetch-depth: 0
+        fetch-tags: true
+        filter: tree:0
+        show-progress: false
+    - name: Setup environment
+      run: >
+        gh release view continuous --json assets,targetCommitish --jq '
+        "COMMIT=" + .targetCommitish,
+        "VERSION=" + ([.assets[].name | match("-([0-9]+)-x86_64\\.AppImage")] | first.captures[0].string // halt_error )
+        ' | tee "$GITHUB_ENV"
+    - name: Retrieve assets
+      run: gh release download --dir build continuous
+    - name: Publish release
+      run: ./scripts/release.sh "$VERSION" "$COMMIT" ./build/*

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+dry_run=''
+if [[ "$1" == '-n' ]]; then
+    dry_run='1'
+    shift
+fi
+
+if [[ $# -lt 3 ]]; then
+    printf 'USAGE: %s NAME TARGET ASSETS…\n' "$0" 1>&2
+    exit 1
+fi
+
+name="$1"
+target="$2"
+shift 2
+
+run() {
+    { printf '%q ' "$@"; printf '\n'; } 1>&2;
+    [[ -z "$dry_run" ]] || return 0
+    "$@"
+}
+
+[[ "$name" == 'continuous' ]] && continuous=1 || continuous=''
+
+if [ -n "$continuous" ]; then
+    title='Continuous Build'
+    previous_tag='continuous'
+else
+    title="$name"
+    previous_tag="$(git tag --list='[0-9]*' --sort=-committerdate --merged | grep --max-count=1 -v "$name")"
+fi
+notes="$(git log --format='format:- %s ([%an](%H))' --no-decorate ${previous_tag:+$previous_tag..} ':!.idea/*' ':!docs/**' ':!**/*.md' ':!*.md')"
+printf '%s: %s\n' \
+    'Name' "$name" \
+    'Title' "$title" \
+    'Previous tag' "$previous_tag" \
+    'Notes' $'\n'"$notes" \
+    ;
+# NOTE: when creating a continuous release, we use a temporary draft release
+# to minimize the window where the continuous release is not accessible.
+new_release="$(run gh release create "$name${continuous:+ [$target]}" ${continuous:+--draft} --prerelease --notes "$notes" --target "$target" --title "$title" "$@")"
+if [ -n "$continuous" ]; then
+    # Delete old release.
+    run gh release delete --cleanup-tag --yes "$name" || true
+    # Publish new release.
+    run gh release edit --draft=false --tag "$name" "${new_release##*/}"
+fi


### PR DESCRIPTION
Version:

- fix discrepancy between filename version number and the version reported by `--help`: for example, `./appimagetool-823-x86_64.AppImage --help` would show 177 for the version instead of 823 (177+646).
- when possible, add commit hash to the reported version: e.g. when building from a local git checkout:
```
▸ ./build/mkappimage-2025-12-12_151653-x86_64.AppImage --help
[…]
VERSION:
   2025-12-12_151653 - 6bb24503a3f5c0d9a6b2f7e2c644347cef0f3c46
[…]
```

Persistent releases:

Tweak the workflow dispatch trigger to allow generating a persistent release:
- from GitHub's website actions' tab: select the "Build All Architectures" workflow, then click on "Run workflow" and tick the "Create a non-continuous release" option before triggering the workflow.
- using the cli: `gh workflow run build.yaml --field non_continuous=true`

Note:
- the `marvinpinto/action-automatic-releases` action has been dropped in favor of just using the GitHub CLI executable:
  - the `marvinpinto/action-automatic-releases` repo is archived
  - there were some warnings about using `set-output` (deprecated) during execution
- release notes are generated with git log (from the previous continuous or persistent release tag, depending on the release type)
- persistent releases are still marked as "Pre-release"