### PR TITLE
Don't clean desktop files & thumbnails on appimaged launch

### DIFF
--- a/src/appimaged/appimaged.go
+++ b/src/appimaged/appimaged.go
@@ -40,7 +40,7 @@ var verbosePtr = flag.Bool("v", false, "Print verbose log messages")
 // information from AppImages (slow), we could just rewrite the path to this
 // program in all desktop files. That should be much faster.
 var overwritePtr = flag.Bool("o", false, "Overwrite existing desktop integration files (slower)")
-var cleanPtr = flag.Bool("c", true, "Clean pre-existing desktop files")
+var cleanPtr = flag.Bool("c", false, "Clean pre-existing desktop files")
 
 var quietPtr = flag.Bool("q", false, "Do not send desktop notifications")
 
@@ -328,7 +328,7 @@ func checkDirectories() {
 			path := filepath.Join(dir, fil.Name())
 			if IsPossibleAppImage(path) {
 				log.Println("integrating", path)
-				AddIntegration(path, false)
+				AddIntegration(path, false, false)
 			}
 		}
 	}

--- a/src/appimaged/inotify.go
+++ b/src/appimaged/inotify.go
@@ -22,7 +22,6 @@ package main
 // us Unix specific and not cross-platform. Therefore, we are using https://github.com/rjeczalik/notify
 
 import (
-	"log"
 	"path/filepath"
 	"strings"
 	"time"
@@ -70,7 +69,6 @@ mainLoop:
 			if !ok {
 				return
 			}
-			log.Println("fsnotify event:", ev)
 			for _, dir := range watchedDirectories {
 				// Deleting or creating a watched directory gives fsnotify.Rename.
 				if dir == ev.Name && ev.Has(fsnotify.Rename) {
@@ -135,7 +133,8 @@ func writeEnd(path string) {
 	_, ok := integrations[path]
 	if goappimage.IsAppImage(path) {
 		if !ok {
-			AddIntegration(path, true)
+			// Force re-integration because an existing AppImage might have been updated/replaced
+			AddIntegration(path, true, true)
 		}
 	} else if ok {
 		RemoveIntegration(path, true)

--- a/src/appimaged/integration.go
+++ b/src/appimaged/integration.go
@@ -18,10 +18,10 @@ var integrations = make(map[string]*AppImage)
 // If this also get's to messy, we can change to a buffered channel system.
 var integrationLock sync.Mutex
 
-func AddIntegration(path string, notify bool) (err error) {
+func AddIntegration(path string, notify bool, force bool) (err error) {
 	integrationLock.Lock()
 	defer integrationLock.Unlock()
-	if _, ok := integrations[path]; ok {
+	if _, ok := integrations[path]; !force && ok {
 		return
 	}
 	ai, err := NewAppImage(path)


### PR DESCRIPTION
* Set `cleanPtr` by default to false since appimaged seems to be stable enough it shouldn't be necessary (fixes #388).
* Remove log on every fsnotify event to prevent log spam (especially on write operations).
* Force AppImage integration after a fsnotify write operation since the file may be replaced. I particularly noticed that If you replaced an AppImage it might not even have the executable permission.